### PR TITLE
Rename the Provider trait to Context

### DIFF
--- a/examples/00-transformations.rs
+++ b/examples/00-transformations.rs
@@ -109,12 +109,12 @@ fn main() -> anyhow::Result<()> {
     // Don't do this!
     // ------------------------------------------------------------------------------
     // As PROJ-conoisseurs know, the `Context` type in PROJ plays a somewhat more
-    // passive role than the `Provider` type in RG. But actually, the RG provider API
+    // passive role than the `Context` type in RG. But actually, the RG Context API
     // is built on top of a much more PROJ-like interface, where the operators take
     // center stage. In general, the use of this interface is *not* recommended, but
     // for the rare cases where it is preferable, we demonstrate its use below, by
     // repeating the exercises above, while swapping the roles of the `Op`/`OpHandle`
-    // and the `Provider`.
+    // and the `Context`.
 
     // Create an `Op`, turning geographical coordinates into UTM zone 32 coordinates
     let utm32 = Op::new("utm zone=32", &ctx)?;

--- a/examples/01-geometric_geodesy.rs
+++ b/examples/01-geometric_geodesy.rs
@@ -12,7 +12,7 @@
 use geodesy::preamble::*;
 
 fn main() -> Result<(), Error> {
-    // In example 00, we saw that the `Provider` data structure is the
+    // In example 00, we saw that the `Context` data structure is the
     // coordinating element for all things related to transformations
     // in Rust Geodesy. For generic geometric geodesy the same can be
     // said about the `Ellipsoid`. So to do anything, we must first

--- a/examples/03-user_defined_operators.rs
+++ b/examples/03-user_defined_operators.rs
@@ -15,7 +15,7 @@ use geodesy::inner_op_authoring::*;
 // It also implements the inverse operation, i.e. subtracting 42.
 
 // Forward
-fn add42(_op: &Op, _provider: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn add42(_op: &Op, _ctx: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let mut n = 0;
     for o in operands {
         o[0] += 42.;
@@ -25,7 +25,7 @@ fn add42(_op: &Op, _provider: &dyn Provider, operands: &mut [Coord]) -> Result<u
 }
 
 // Inverse
-fn sub42(_op: &Op, _provider: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn sub42(_op: &Op, _ctx: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let mut n = 0;
     for o in operands {
         o[0] -= 42.;
@@ -37,9 +37,9 @@ fn sub42(_op: &Op, _provider: &dyn Provider, operands: &mut [Coord]) -> Result<u
 // These are the parameters our 'add42'-operator are willing to respond to
 pub const GAMUT: [OpParameter; 1] = [OpParameter::Flag { key: "inv" }];
 
-// And this is the constructor, generating the object, the provider needs to instantiate an actual instance
-pub fn add42_constructor(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
-    Op::plain(parameters, InnerOp(add42), InnerOp(sub42), &GAMUT, provider)
+// And this is the constructor, generating the object, the `Context` needs to instantiate an actual instance
+pub fn add42_constructor(parameters: &RawParameters, ctx: &dyn Context) -> Result<Op, Error> {
+    Op::plain(parameters, InnerOp(add42), InnerOp(sub42), &GAMUT, ctx)
 }
 
 fn main() -> anyhow::Result<()> {

--- a/examples/04-rotating_the_earth.rs
+++ b/examples/04-rotating_the_earth.rs
@@ -33,7 +33,7 @@ fn main() {}
 /*
 use geodesy::Ellipsoid;
 use geodesy::Error;
-use geodesy::{CoordinateTuple, Provider};
+use geodesy::{CoordinateTuple, Context};
 
 pub struct GeodesicShift {
     args: Vec<(String, String)>,
@@ -84,14 +84,14 @@ impl GeodesicShift {
 
     // This is the interface to the Rust Geodesy library: Construct a
     // GeodesicShift element, and wrap it properly for consumption.
-    pub fn operator(args: &GysResource, _rp: &dyn Provider) -> Result<Operator, GeodesyError> {
+    pub fn operator(args: &GysResource, _rp: &dyn Context) -> Result<Operator, GeodesyError> {
         let op = GeodesicShift::new(args)?;
         Ok(Operator(Box::new(op)))
     }
 }
 
 impl OperatorCore for GeodesicShift {
-    fn fwd(&self, _ctx: &dyn Provider, operands: &mut [CoordinateTuple]) -> bool {
+    fn fwd(&self, _ctx: &dyn Context, operands: &mut [CoordinateTuple]) -> bool {
         for coord in operands {
             let res = self.ellps.geodesic_fwd(&coord, self.bearing, self.distance);
             coord[0] = res[0];

--- a/ruminations/002-rumination.md
+++ b/ruminations/002-rumination.md
@@ -220,7 +220,7 @@ The `gridshift` operator implements datum shifts by interpolation in correction 
 | `inv` | Inverse operation: output-to-input datum. For 2-D and 3-D cases, this involves an iterative refinement, typically converging after less than 5 iterations |
 | `grids` | Name of the grid file to use. RG supports only one file for each operation, but maintains the plural form of the `grids` option for alignment with the PROJ precedent |
 
-The `gridshift` operator has built in support for the **Gravsoft** grid format. Support for additional file formats depends on the `Provider` in use.
+The `gridshift` operator has built in support for the **Gravsoft** grid format. Support for additional file formats depends on the `Context` in use.
 
 **Units:**
 For grids with angular (geographical) spatial units, the corrections are supposed to be given in seconds of arc, and internally converted to radians. For grids appearing to have linear (projected) spatial units, the corrections are supposed to be given in meters, and are kept unchanged. A grid is supposed to be in linear spatial units if any of its boundaries have a numerical value larger than `2×360`, i.e. clearly outside of the angular range.

--- a/ruminations/004-rumination.md
+++ b/ruminations/004-rumination.md
@@ -60,13 +60,13 @@ Context style data types are annoying, but experience from work on both PROJ and
 
 ### Solution #2: The OS interface abstraction
 
-In Rust Geodesy, the OS interface is handled by a structure called "the provider". To make the provider less annoying than a PROJ context, it has been given much more functionality, so it's not just a bolted on afterthought, *but the actual API* for accessing the system functionality.
+In Rust Geodesy, the OS interface is handled by a structure called "the Context". To make the Context less annoying than a PROJ context, it has been given much more functionality, so it's not just a bolted on afterthought, *but the actual API* for accessing the system functionality.
 
-To (potentially) reduce the annoying aspect even further, there is not just one provider implementation, but two - `Minimal` and `Plain`, respectively. `Minimal` is much in the style of "classic" PROJ, while `Plain` in principle provides access to externally defined transformations from e.g. the EPSG registry (i.e. "resolver" functionality). Unlike PROJ, however, the definitions used by `Plain` are to be represented in user provided plain text files, not in a SQLite file database.
+To (potentially) reduce the annoying aspect even further, there is not just one Context implementation, but two - `Minimal` and `Plain`, respectively. `Minimal` is much in the style of "classic" PROJ, while `Plain` in principle provides access to externally defined transformations from e.g. the EPSG registry (i.e. "resolver" functionality). Unlike PROJ, however, the definitions used by `Plain` are to be represented in user provided plain text files, not in a SQLite file database.
 
-Hence, Rust Geodesy does not depend on external database functionality. The provider functionality is, however, represented by a Trait, not by fixed data structures, so users wishing to support PROJ's SQLite representation of the EPSG registry, can implement their own provider, supporting that.
+Hence, Rust Geodesy does not depend on external database functionality. The Context functionality is, however, represented by a Trait, not by fixed data structures, so users wishing to support PROJ's SQLite representation of the EPSG registry, can implement their own Context, supporting that.
 
-In a sense, this reflects the modularity of the transformation operator implementation onto the provider implementation: You can use one of the built ins, or you can provide your own. This allows for a very slim core functionality, that can be expanded as needed in actual use cases. In PROJ, the introduction of SQLite as a dependency resulted in much whining: The unreasonable expectations/unfounded entitlement is smoke thick over at <https://github.com/OSGeo/PROJ/issues/1552>. But since RG has the good fortune of being able to learn from PROJ,  why build a monolithic provider/resolver-architecture, when we don't have to? The operator architecture is modular, after all.
+In a sense, this reflects the modularity of the transformation operator implementation onto the Context implementation: You can use one of the built ins, or you can provide your own. This allows for a very slim core functionality, that can be expanded as needed in actual use cases. In PROJ, the introduction of SQLite as a dependency resulted in much whining: The unreasonable expectations/unfounded entitlement is smoke thick over at <https://github.com/OSGeo/PROJ/issues/1552>. But since RG has the good fortune of being able to learn from PROJ,  why build a monolithic Context/resolver-architecture, when we don't have to? The operator architecture is modular, after all.
 
 ### Problem #3: The geodetic registry interface ("the resolver")
 
@@ -96,7 +96,7 @@ One might object that resolving to building on user selection of the exact trans
 
 ### Solution #3: The geodetic registry interface ("the resolver")
 
-Where PROJ supports both "find the proper transformation given input and output CRS", and "use this transformation - do not ask any questions", RG deems the concept of a resolver implausible in the general case, and leaves the implementation of one up the end user, by whom it may be implemented as part of a `Provider` data structure.
+Where PROJ supports both "find the proper transformation given input and output CRS", and "use this transformation - do not ask any questions", RG deems the concept of a resolver implausible in the general case, and leaves the implementation of one up the end user, by whom it may be implemented as part of a `Context` data structure.
 
 
 ### Document History

--- a/src/context/minimal.rs
+++ b/src/context/minimal.rs
@@ -14,7 +14,7 @@ pub struct Minimal {
     operators: BTreeMap<OpHandle, Op>,
 }
 
-impl Provider for Minimal {
+impl Context for Minimal {
     fn new() -> Minimal {
         let mut prv = Minimal::default();
         for item in BUILTIN_ADAPTORS {
@@ -91,7 +91,7 @@ impl Provider for Minimal {
     /// Access grid resources by identifier
     fn get_grid(&self, _name: &str) -> Result<Grid, Error> {
         Err(Error::General(
-            "Grid access by identifier not supported by the Minimal Provider",
+            "Grid access by identifier not supported by the Minimal context provider",
         ))
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -8,10 +8,10 @@ use super::internal::*;
 
 // ----- T H E   P R O V I D E R   T R A I T -------------------------------------------
 
-/// The `Provider` trait defines the mode of communication between *Rust Geodesy* internals
+/// The `Context` trait defines the mode of communication between *Rust Geodesy* internals
 /// and the external context (i.e. typically resources like grids, transformation definitions,
 /// or ellipsoid parameters).
-pub trait Provider {
+pub trait Context {
     fn new() -> Self
     where
         Self: Sized;
@@ -46,7 +46,7 @@ pub trait Provider {
     fn get_grid(&self, name: &str) -> Result<Grid, Error>;
 }
 
-// Help providers provide canonically named, built in coordinate adaptors
+// Help context providers provide canonically named, built in coordinate adaptors
 #[rustfmt::skip]
 const BUILTIN_ADAPTORS: [(&str, &str); 8] = [
     ("geo:in",  "adapt from=neut_deg"),

--- a/src/context/plain.rs
+++ b/src/context/plain.rs
@@ -40,7 +40,7 @@ impl Default for Plain {
     }
 }
 
-impl Provider for Plain {
+impl Context for Plain {
     fn new() -> Plain {
         let mut prv = Plain::default();
         for item in BUILTIN_ADAPTORS {
@@ -138,7 +138,7 @@ impl Provider for Plain {
     /// Access grid resources by identifier
     fn get_grid(&self, _name: &str) -> Result<Grid, Error> {
         Err(Error::General(
-            "Grid access by identifier not supported by the Minimal Provider",
+            "Grid access by identifier not supported by the Plain context provider",
         ))
     }
 }

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -1,6 +1,6 @@
 // The Grid struct handles grid characteristics and interpolation.
 // The actual grid may be ither part of the Grid struct, or externally
-// provided (presumably by a Provider).
+// provided (presumably by a Context).
 //
 // In principle grid format agnostic, but includes a parser for
 // Gravsoft format geodetic grids.
@@ -36,7 +36,7 @@ pub struct Grid {
     pub bands: usize,
     offset: usize, // typically 0, but may be any number for externally stored grids
     last_valid_record_start: usize,
-    grid: Vec<f32>, // May be zero sized in cases where the Provider provides access to an externally stored grid
+    grid: Vec<f32>, // May be zero sized in cases where the Context provides access to an externally stored grid
 }
 
 impl Grid {

--- a/src/inner_op/adapt.rs
+++ b/src/inner_op/adapt.rs
@@ -64,7 +64,7 @@ const MULT_DEFAULT: [f64; 4] = [1., 1., 1., 1.];
 
 // ----- F O R W A R D --------------------------------------------------------------
 
-fn fwd(op: &Op, _prv: &dyn Provider, data: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, _prv: &dyn Context, data: &mut [Coord]) -> Result<usize, Error> {
     let n = data.len();
     if op.params.boolean("noop") {
         return Ok(n);
@@ -91,7 +91,7 @@ fn fwd(op: &Op, _prv: &dyn Provider, data: &mut [Coord]) -> Result<usize, Error>
 
 // ----- I N V E R S E --------------------------------------------------------------
 
-fn inv(op: &Op, _prv: &dyn Provider, data: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, _prv: &dyn Context, data: &mut [Coord]) -> Result<usize, Error> {
     let n = data.len();
     if op.params.boolean("noop") {
         return Ok(n);
@@ -129,7 +129,7 @@ pub const GAMUT: [OpParameter; 3] = [
     OpParameter::Text { key: "to", default: Some("enut") },
 ];
 
-pub fn new(parameters: &RawParameters, _provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, _provider: &dyn Context) -> Result<Op, Error> {
     let mut params = ParsedParameters::new(parameters, &GAMUT)?;
     let descriptor = OpDescriptor::new(&parameters.definition, InnerOp(fwd), Some(InnerOp(inv)));
     let steps = Vec::<Op>::new();

--- a/src/inner_op/addone.rs
+++ b/src/inner_op/addone.rs
@@ -2,7 +2,7 @@ use super::*;
 
 // ----- F O R W A R D -----------------------------------------------------------------
 
-fn fwd(_op: &Op, _provider: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(_op: &Op, _provider: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let mut n = 0;
     for o in operands {
         o[0] += 1.;
@@ -13,7 +13,7 @@ fn fwd(_op: &Op, _provider: &dyn Provider, operands: &mut [Coord]) -> Result<usi
 
 // ----- I N V E R S E -----------------------------------------------------------------
 
-fn inv(_op: &Op, _provider: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(_op: &Op, _provider: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let mut n = 0;
     for o in operands {
         o[0] -= 1.;
@@ -29,7 +29,7 @@ pub const GAMUT: [OpParameter; 1] = [
     OpParameter::Flag { key: "inv" },
 ];
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, provider: &dyn Context) -> Result<Op, Error> {
     Op::plain(parameters, InnerOp(fwd), InnerOp(inv), &GAMUT, provider)
 }
 

--- a/src/inner_op/cart.rs
+++ b/src/inner_op/cart.rs
@@ -5,7 +5,7 @@ use super::*;
 
 // ----- F O R W A R D --------------------------------------------------------------
 
-fn cart_fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn cart_fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let mut n = 0_usize;
     for coord in operands {
         *coord = op.params.ellps[0].cartesian(coord);
@@ -18,7 +18,7 @@ fn cart_fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usiz
 
 // ----- I N V E R S E --------------------------------------------------------------
 
-fn cart_inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn cart_inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     // eccentricity squared, Fukushima's E, Claessens' c3 = 1-c2`
     let es = op.params.ellps[0].eccentricity_squared();
     // semiminor axis
@@ -95,7 +95,7 @@ pub const GAMUT: [OpParameter; 2] = [
     OpParameter::Text { key: "ellps", default: Some("GRS80") },
 ];
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, provider: &dyn Context) -> Result<Op, Error> {
     Op::plain(
         parameters,
         InnerOp(cart_fwd),

--- a/src/inner_op/etmerc.rs
+++ b/src/inner_op/etmerc.rs
@@ -6,7 +6,7 @@ use super::*;
 // ----- F O R W A R D -----------------------------------------------------------------
 
 // Forward transverse mercator, following Engsager & Poder(2007)
-fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let ellps = op.params.ellps[0];
     let lat_0 = op.params.lat[0];
     let lon_0 = op.params.lon[0];
@@ -87,7 +87,7 @@ fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Er
 // ----- I N V E R S E -----------------------------------------------------------------
 
 // Inverse Transverse Mercator, following Engsager & Poder (2007) (currently Bowring stands in!)
-fn inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let ellps = op.params.ellps[0];
     let lon_0 = op.params.lon[0];
     let x_0 = op.params.x[0];
@@ -184,7 +184,7 @@ const TRANSVERSE_MERCATOR: PolynomialCoefficients = PolynomialCoefficients {
     ]
 };
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, provider: &dyn Context) -> Result<Op, Error> {
     let mut op = Op::plain(parameters, InnerOp(fwd), InnerOp(inv), &GAMUT, provider)?;
     let ellps = op.params.ellps[0];
     let n = ellps.third_flattening();

--- a/src/inner_op/gridshift.rs
+++ b/src/inner_op/gridshift.rs
@@ -1,10 +1,10 @@
 // Datum shift using grid interpolation.
 use super::*;
-use crate::Provider;
+use crate::Context;
 
 // ----- F O R W A R D --------------------------------------------------------------
 
-fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let grid = &op.params.grids["grid"];
     let mut successes = 0_usize;
 
@@ -34,7 +34,7 @@ fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Er
 
 // ----- I N V E R S E --------------------------------------------------------------
 
-fn inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let grid = &op.params.grids["grid"];
     let mut successes = 0_usize;
 
@@ -78,7 +78,7 @@ pub const GAMUT: [OpParameter; 3] = [
     OpParameter::Real { key: "padding", default: Some(0.5) },
 ];
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, provider: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let mut params = ParsedParameters::new(parameters, &GAMUT)?;
 

--- a/src/inner_op/helmert.rs
+++ b/src/inner_op/helmert.rs
@@ -14,7 +14,7 @@ use super::*;
 
 fn helmert_common(
     op: &Op,
-    _prv: &dyn Provider,
+    _prv: &dyn Context,
     operands: &mut [Coord],
     direction: Direction,
 ) -> usize {
@@ -111,13 +111,13 @@ fn helmert_common(
 
 // ----- F O R W A R D --------------------------------------------------------------
 
-fn helmert_fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn helmert_fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     Ok(helmert_common(op, _prv, operands, Direction::Fwd))
 }
 
 // ----- I N V E R S E --------------------------------------------------------------
 
-fn helmert_inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn helmert_inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     Ok(helmert_common(op, _prv, operands, Direction::Inv))
 }
 
@@ -162,7 +162,7 @@ pub const GAMUT: [OpParameter; 19] = [
     OpParameter::Real { key: "t_obs", default: Some(std::f64::NAN) },
 ];
 
-pub fn new(parameters: &RawParameters, _provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, _provider: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let mut params = ParsedParameters::new(parameters, &GAMUT)?;
 

--- a/src/inner_op/lcc.rs
+++ b/src/inner_op/lcc.rs
@@ -8,7 +8,7 @@ const EPS10: f64 = 1e-10;
 
 // Forward Lambert conformal conic, following the PROJ implementation,
 // cf.  https://proj.org/operations/projections/lcc.html
-fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let a = op.params.ellps[0].semimajor_axis();
     let e = op.params.ellps[0].eccentricity();
     let lon_0 = op.params.lon[0];
@@ -43,7 +43,7 @@ fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Er
 }
 
 // ----- I N V E R S E -----------------------------------------------------------------
-fn inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let a = op.params.ellps[0].semimajor_axis();
     let e = op.params.ellps[0].eccentricity();
     let lon_0 = op.params.lon[0];
@@ -107,7 +107,7 @@ pub const GAMUT: [OpParameter; 9] = [
     OpParameter::Real { key: "y_0",   default: Some(0_f64) },
 ];
 
-pub fn new(parameters: &RawParameters, _provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, _provider: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let mut params = ParsedParameters::new(parameters, &GAMUT)?;
     if params.lat[2].is_nan() {

--- a/src/inner_op/merc.rs
+++ b/src/inner_op/merc.rs
@@ -3,7 +3,7 @@ use super::*;
 
 // ----- F O R W A R D -----------------------------------------------------------------
 
-fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let ellps = op.params.ellps[0];
     let a = ellps.semimajor_axis();
     let k_0 = op.params.k[0];
@@ -29,7 +29,7 @@ fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Er
 
 // ----- I N V E R S E -----------------------------------------------------------------
 
-fn inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let ellps = op.params.ellps[0];
     let a = ellps.semimajor_axis();
     let k_0 = op.params.k[0];
@@ -70,7 +70,7 @@ pub const GAMUT: [OpParameter; 8] = [
     OpParameter::Real { key: "lat_ts", default: Some(0_f64) },
 ];
 
-pub fn new(parameters: &RawParameters, _provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, _provider: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let mut params = ParsedParameters::new(parameters, &GAMUT)?;
     let ellps = params.ellps[0];

--- a/src/inner_op/mod.rs
+++ b/src/inner_op/mod.rs
@@ -60,7 +60,7 @@ pub fn builtin(name: &str) -> Result<OpConstructor, Error> {
 /// OpConstructor needs to be a newtype, rather than a type alias,
 /// since we must implement the Debug-trait for OpConstructor (to
 /// make auto derive of the Debug-trait work for any derived type).
-pub struct OpConstructor(pub fn(args: &RawParameters, ctx: &dyn Provider) -> Result<Op, Error>);
+pub struct OpConstructor(pub fn(args: &RawParameters, ctx: &dyn Context) -> Result<Op, Error>);
 
 // Cannot autoderive the Debug trait
 impl core::fmt::Debug for OpConstructor {
@@ -76,7 +76,7 @@ impl core::fmt::Debug for OpConstructor {
 /// must implement the Debug-trait for InnerOp (to make auto derive
 /// of the Debug-trait work for any derived type).
 pub struct InnerOp(
-    pub fn(op: &Op, ctx: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error>,
+    pub fn(op: &Op, ctx: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error>,
 );
 
 // Cannot autoderive the Debug trait
@@ -95,7 +95,7 @@ impl Default for InnerOp {
 
 fn noop_placeholder(
     _params: &Op,
-    _provider: &dyn Provider,
+    _provider: &dyn Context,
     _operands: &mut [Coord],
 ) -> Result<usize, Error> {
     // Consider whether this should return an Err-value if used as a placeholder for a

--- a/src/inner_op/molodensky.rs
+++ b/src/inner_op/molodensky.rs
@@ -21,7 +21,7 @@ use super::*;
 
 fn common(
     op: &Op,
-    _prv: &dyn Provider,
+    _prv: &dyn Context,
     operands: &mut [Coord],
     direction: Direction,
 ) -> Result<usize, Error> {
@@ -69,12 +69,12 @@ fn common(
 }
 
 // ----- F O R W A R D -----------------------------------------------------------------
-fn fwd(op: &Op, prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     common(op, prv, operands, Fwd)
 }
 
 // ----- I N V E R S E -----------------------------------------------------------------
-fn inv(op: &Op, prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     common(op, prv, operands, Inv)
 }
 
@@ -94,7 +94,7 @@ pub const GAMUT: [OpParameter; 10] = [
     OpParameter::Text { key: "ellps_1",  default: Some("GRS80") },
 ];
 
-pub fn new(parameters: &RawParameters, _provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, _provider: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let mut params = ParsedParameters::new(parameters, &GAMUT)?;
 

--- a/src/inner_op/nmea.rs
+++ b/src/inner_op/nmea.rs
@@ -22,7 +22,7 @@ use super::*;
 
 // ----- F O R W A R D -----------------------------------------------------------------
 
-fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let dms = op.params.boolean("dms");
     let mut successes = 0_usize;
     for o in operands {
@@ -39,7 +39,7 @@ fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Er
 
 // ----- I N V E R S E -----------------------------------------------------------------
 
-fn inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let dms = op.params.boolean("dms");
     let mut successes = 0_usize;
     for o in operands {
@@ -67,7 +67,7 @@ pub const GAMUT: [OpParameter; 2] = [
     OpParameter::Flag { key: "dms" }
 ];
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, provider: &dyn Context) -> Result<Op, Error> {
     Op::plain(parameters, InnerOp(fwd), InnerOp(inv), &GAMUT, provider)
 }
 

--- a/src/inner_op/noop.rs
+++ b/src/inner_op/noop.rs
@@ -3,13 +3,13 @@ use super::*;
 
 // ----- F O R W A R D --------------------------------------------------------------
 
-fn fwd(_op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(_op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     Ok(operands.len())
 }
 
 // ----- I N V E R S E --------------------------------------------------------------
 
-fn inv(_op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(_op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     Ok(operands.len())
 }
 
@@ -20,7 +20,7 @@ fn inv(_op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, E
 pub const GAMUT: [OpParameter; 0] = [
 ];
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, provider: &dyn Context) -> Result<Op, Error> {
     Op::plain(parameters, InnerOp(fwd), InnerOp(inv), &GAMUT, provider)
 }
 

--- a/src/inner_op/pipeline.rs
+++ b/src/inner_op/pipeline.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 
 // ----- F O R W A R D -----------------------------------------------------------------
 
-fn pipeline_fwd(op: &Op, provider: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn pipeline_fwd(op: &Op, provider: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let mut stack = Vec::new();
     let mut n = usize::MAX;
     for step in &op.steps {
@@ -27,7 +27,7 @@ fn pipeline_fwd(op: &Op, provider: &dyn Provider, operands: &mut [Coord]) -> Res
 
 // ----- I N V E R S E -----------------------------------------------------------------
 
-fn pipeline_inv(op: &Op, provider: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn pipeline_inv(op: &Op, provider: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let mut stack = Vec::new();
     let mut n = usize::MAX;
     for step in op.steps.iter().rev() {
@@ -57,7 +57,7 @@ pub const GAMUT: [OpParameter; 1] = [
     OpParameter::Flag { key: "inv" },
 ];
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, provider: &dyn Context) -> Result<Op, Error> {
     let definition = &parameters.definition;
     let thesteps = split_into_steps(definition).0;
     let mut steps = Vec::new();
@@ -94,7 +94,7 @@ pub const PUSH_POP_GAMUT: [OpParameter; 4] = [
     OpParameter::Flag { key: "v_4" },
 ];
 
-pub fn push(parameters: &RawParameters, _prv: &dyn Provider) -> Result<Op, Error> {
+pub fn push(parameters: &RawParameters, _prv: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let params = ParsedParameters::new(parameters, &PUSH_POP_GAMUT)?;
 
@@ -114,7 +114,7 @@ pub fn push(parameters: &RawParameters, _prv: &dyn Provider) -> Result<Op, Error
     })
 }
 
-pub fn pop(parameters: &RawParameters, _prv: &dyn Provider) -> Result<Op, Error> {
+pub fn pop(parameters: &RawParameters, _prv: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let params = ParsedParameters::new(parameters, &PUSH_POP_GAMUT)?;
 

--- a/src/inner_op/proj.rs
+++ b/src/inner_op/proj.rs
@@ -83,13 +83,13 @@ fn proj(args: &str, forward: bool, operands: &mut [Coord]) -> Result<usize, Erro
 
 // ----- F O R W A R D --------------------------------------------------------------
 
-fn proj_fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn proj_fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     proj(&op.params.text["proj_args"], true, operands)
 }
 
 // ----- I N V E R S E --------------------------------------------------------------
 
-fn proj_inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn proj_inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     proj(&op.params.text["proj_args"], false, operands)
 }
 
@@ -100,7 +100,7 @@ pub const GAMUT: [OpParameter; 1] = [
     OpParameter::Flag { key: "inv" },
 ];
 
-pub fn new(parameters: &RawParameters, _provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, _provider: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let given_args = ParsedParameters::new(parameters, &GAMUT)?.given;
     if Command::new("proj").stderr(Stdio::piped()).spawn().is_err() {

--- a/src/inner_op/template.rs
+++ b/src/inner_op/template.rs
@@ -6,7 +6,7 @@ use super::*;
 
 // ----- F O R W A R D -----------------------------------------------------------------
 
-fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     todo!();
     let mut successes = 0_usize;
     for coord in operands {
@@ -19,7 +19,7 @@ fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Er
 
 // ----- I N V E R S E -----------------------------------------------------------------
 
-fn inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     todo!();
     let mut successes = 0_usize;
     for coord in operands {
@@ -40,8 +40,8 @@ pub const GAMUT: [OpParameter; 3] = [
     OpParameter::Text { key: "convention", default: Some("") },
 ];
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
-    Op::plain(parameters, InnerOp(fwd), InnerOp(inv), &GAMUT, provider)
+pub fn new(parameters: &RawParameters, Context: &dyn Context) -> Result<Op, Error> {
+    Op::plain(parameters, InnerOp(fwd), InnerOp(inv), &GAMUT, Context)
 }
 
 // ----- A N C I L L A R Y   F U N C T I O N S -----------------------------------------
@@ -55,20 +55,20 @@ mod tests {
 
     #[test]
     fn template() -> Result<(), Error> {
-        let provider = Minimal::default();
-        let op = Op::new("helmert x=-87 y=-96 z=-120", &provider)?;
+        let Context = Minimal::default();
+        let op = Op::new("helmert x=-87 y=-96 z=-120", &Context)?;
 
         // EPSG:1134 - 3 parameter, ED50/WGS84, s = sqrt(27) m
         let mut operands = [Coord::origin()];
 
         // Forward
-        op.apply(&provider, &mut operands, Fwd)?;
+        op.apply(&Context, &mut operands, Fwd)?;
         assert_eq!(operands[0].first(), -87.);
         assert_eq!(operands[0].second(), -96.);
         assert_eq!(operands[0].third(), -120.);
 
         // Inverse + roundtrip
-        op.apply(&provider, &mut operands, Inv)?;
+        op.apply(&Context, &mut operands, Inv)?;
         assert_eq!(operands[0].first(), 0.);
         assert_eq!(operands[0].second(), 0.);
         assert_eq!(operands[0].third(), 0.);

--- a/src/inner_op/tmerc.rs
+++ b/src/inner_op/tmerc.rs
@@ -4,7 +4,7 @@ use super::*;
 // ----- F O R W A R D -----------------------------------------------------------------
 
 // Forward transverse mercator, following Bowring (1989)
-fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn fwd(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let ellps = op.params.ellps[0];
     let eps = ellps.second_eccentricity_squared();
     let lat_0 = op.params.lat[0];
@@ -48,7 +48,7 @@ fn fwd(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Er
 // ----- I N V E R S E -----------------------------------------------------------------
 
 // Inverse transverse mercator, following Bowring (1989)
-fn inv(op: &Op, _prv: &dyn Provider, operands: &mut [Coord]) -> Result<usize, Error> {
+fn inv(op: &Op, _prv: &dyn Context, operands: &mut [Coord]) -> Result<usize, Error> {
     let ellps = op.params.ellps[0];
     let eps = ellps.second_eccentricity_squared();
     let lat_0 = op.params.lat[0];
@@ -102,7 +102,7 @@ pub const GAMUT: [OpParameter; 7] = [
     OpParameter::Real { key: "k_0",   default: Some(1_f64) },
 ];
 
-pub fn new(parameters: &RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+pub fn new(parameters: &RawParameters, provider: &dyn Context) -> Result<Op, Error> {
     Op::plain(parameters, InnerOp(fwd), InnerOp(inv), &GAMUT, provider)
 }
 
@@ -113,7 +113,7 @@ pub const UTM_GAMUT: [OpParameter; 3] = [
     OpParameter::Natural { key: "zone", default: None },
 ];
 
-pub fn utm(parameters: &RawParameters, _prv: &dyn Provider) -> Result<Op, Error> {
+pub fn utm(parameters: &RawParameters, _prv: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let mut params = ParsedParameters::new(parameters, &UTM_GAMUT)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,21 +10,22 @@ pub(crate) mod grid;
 mod inner_op;
 pub mod math;
 mod op;
-mod provider;
+mod context;
 
 // The bread-and-butter
 pub use crate::coord::Coord;
 pub use crate::ellipsoid::Ellipsoid;
 pub use crate::grid::Grid;
 pub use crate::op::Op;
-pub use crate::provider::Minimal;
-pub use crate::provider::Plain;
-pub use crate::provider::Provider;
+pub use crate::context::Context;
+pub use crate::context::Minimal;
+pub use crate::context::Plain;
 
 /// The bread-and-butter, shrink-wrapped for external use
 pub mod preamble {
     pub use crate::coord::Coord;
     pub use crate::op::OpHandle;
+    pub use crate::Context;
     pub use crate::Direction;
     pub use crate::Direction::Fwd;
     pub use crate::Direction::Inv;
@@ -33,7 +34,6 @@ pub mod preamble {
     pub use crate::Minimal;
     pub use crate::Op;
     pub use crate::Plain;
-    pub use crate::Provider;
 }
 
 /// Preamble for InnerOp modules (built-in or user defined)

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -36,7 +36,7 @@ impl Op {
     // operate fwd/inv, taking operator inversion into account.
     pub fn apply(
         &self,
-        ctx: &dyn Provider,
+        ctx: &dyn Context,
         operands: &mut [Coord],
         direction: Direction,
     ) -> Result<usize, Error> {
@@ -48,7 +48,7 @@ impl Op {
         self.descriptor.inv.0(self, ctx, operands)
     }
 
-    pub fn new(definition: &str, provider: &dyn Provider) -> Result<Op, Error> {
+    pub fn new(definition: &str, provider: &dyn Context) -> Result<Op, Error> {
         let globals = provider.globals();
         let parameters = RawParameters::new(definition, &globals);
         Self::op(parameters, provider)
@@ -63,7 +63,7 @@ impl Op {
         fwd: InnerOp,
         inv: InnerOp,
         gamut: &[OpParameter],
-        _provider: &dyn Provider,
+        _provider: &dyn Context,
     ) -> Result<Op, Error> {
         let def = parameters.definition.as_str();
         let params = ParsedParameters::new(parameters, gamut)?;
@@ -83,7 +83,7 @@ impl Op {
     // of precendence between pipelines, user defined operators, macros, and
     // built-in operators
     #[allow(clippy::self_named_constructors)]
-    pub fn op(parameters: RawParameters, provider: &dyn Provider) -> Result<Op, Error> {
+    pub fn op(parameters: RawParameters, provider: &dyn Context) -> Result<Op, Error> {
         if parameters.nesting_too_deep() {
             return Err(Error::Recursion(
                 parameters.invocation,

--- a/tests/maximal.rs
+++ b/tests/maximal.rs
@@ -2,7 +2,7 @@ use geodesy::internal::*;
 
 // ----- U S E R   P R O V I D E D   P R O V I D E R ----------------------------------
 
-/// A direct copy of the code of the Minimal provider, renamed as Maximal.
+/// A direct copy of the code of the Minimal Context provider, renamed as Maximal.
 /// Here used as a test and demo of how to write/use a user-provided context
 /// provider.
 ///
@@ -11,8 +11,8 @@ use geodesy::internal::*;
 /// outside of the Rust Geodesy source tree.
 ///
 /// The test in the "tests" section is identical to the one from inner-ops/gridshift.rs
-/// and serves only to show that a user provided provider is used in exactly the same
-/// way as a system provided.
+/// and serves only to show that a user provided context provider is used in exactly
+///  the same way as a system provided.
 
 #[derive(Debug, Default)]
 pub struct Maximal {
@@ -24,7 +24,7 @@ pub struct Maximal {
     operators: BTreeMap<OpHandle, Op>,
 }
 
-impl Provider for Maximal {
+impl Context for Maximal {
     fn new() -> Maximal {
         Maximal::default()
     }
@@ -97,7 +97,7 @@ impl Provider for Maximal {
     /// Access grid resources by identifier
     fn get_grid(&self, _name: &str) -> Result<Grid, Error> {
         Err(Error::General(
-            "Grid access by identifier not supported by the Minimal Provider",
+            "Grid access by identifier not supported by the Maximal context provider",
         ))
     }
 }


### PR DESCRIPTION
With the introduction of the general provider trait for Rust Error messaging, the Provider name has been hijacked for a better cause.

As the Provider (now Context) trait essentially plays the same role for Rust Geodesy as the PJ_CONTEXT object does for PROJ, this name change makes very good sense under all circumstances.