### PR TITLE
add js feature for compiling in wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,14 @@ default-run = "kp"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+js = ["uuid/js"]
+
 [dependencies]
 # Core functionality
 dirs = "4.0"
 # memmap = "0.7"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
 
 # Command line program helpers
 clap = { version = "3.1.18", features = ["derive"] }
@@ -35,4 +38,4 @@ anyhow = "1.0"
 
 
 [profile.release]
-strip = true  # Automatically strip symbols from the binary.
+strip = true # Automatically strip symbols from the binary.


### PR DESCRIPTION
This compiles to wasm for me with:
```
cargo build --features js --target wasm32-unknown-unknown
```

I think it _should_ be possible to have this work automatically by adding 
```
# enable js feature for uuid to work in wasm
[target.'cfg(target_family = "wasm")'.dependencies.uuid]
features = ["js"]
```
([source in polars' `Cargo.toml`](https://github.com/pola-rs/polars/blob/44bd9ac44c6d4d5d688a375e7d5fde90f8d13588/polars/Cargo.toml#L303-L305))

But when I run that Cargo tells me:
```
warning: dependency (uuid) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
```
so maybe you need something more complex, like separating `uuid` into "in-wasm" and "out-of-wasm"