### PR TITLE
Better assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = {version="0.10.0", optional = true}
 # Library level logging and error handling
 log = "0.4"
 thiserror = "1.0"
+float_eq = "1"
 
 [dev-dependencies]
 # Needed for building doc-tests

--- a/src/bin/kp.rs
+++ b/src/bin/kp.rs
@@ -226,6 +226,7 @@ fn transform(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use float_eq::assert_float_eq;
 
     fn some_basic_coordinates() -> [Coor4D; 2] {
         let copenhagen = Coor4D::raw(55., 12., 0., 0.);
@@ -240,12 +241,10 @@ mod tests {
         let op = ctx.op("geo:in | utm zone=32 | neu:out")?;
 
         let mut data = some_basic_coordinates();
-        assert_eq!(data[0][0], 55.);
-        assert_eq!(data[1][0], 59.);
+        let expected = [6098907.825005002, 691875.6321396609, 0., 0.];
 
         ctx.apply(op, Fwd, &mut data)?;
-        assert!((data[0][0] - 6098907.82501).abs() < 1e-4);
-        assert!((data[0][1] - 691875.63214).abs() < 1e-4);
+        assert_float_eq!(data[0].0, expected, abs_all <= 1e-9);
 
         // The text definitions of each step
         let steps = ctx.steps(op)?;

--- a/src/context/minimal.rs
+++ b/src/context/minimal.rs
@@ -126,6 +126,7 @@ impl Context for Minimal {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use float_eq::assert_float_eq;
 
     #[test]
     fn basic() -> Result<(), Error> {
@@ -135,7 +136,7 @@ mod tests {
         ctx.register_resource("stupid:way", "addone | addone | addone inv");
         let op = ctx.op("stupid:way")?;
 
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[1][0], 59.);
 
@@ -165,13 +166,13 @@ mod tests {
 
         let op = ctx.op("geo:in | utm zone=32 | neu:out")?;
 
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[1][0], 59.);
 
         ctx.apply(op, Fwd, &mut data)?;
-        assert!((data[0][0] - 6098907.82501).abs() < 1e-4);
-        assert!((data[0][1] - 691875.63214).abs() < 1e-4);
+        let expected = [6098907.825005002, 691875.6321396609];
+        assert_float_eq!(data[0].0, expected, abs_all <= 1e-10);
 
         // The text definitions of each step
         let steps = ctx.steps(op)?;

--- a/src/context/plain.rs
+++ b/src/context/plain.rs
@@ -222,6 +222,7 @@ impl Context for Plain {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use float_eq::assert_float_eq;
 
     #[test]
     fn basic() -> Result<(), Error> {
@@ -245,7 +246,7 @@ mod tests {
         let op = ctx.op("stupid:way")?;
 
         // ...and it works as expected?
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[1][0], 59.);
 
@@ -275,7 +276,7 @@ mod tests {
         let op = ctx.op("stupid:way_too")?;
 
         // ...and it works as expected?
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
 
         ctx.apply(op, Fwd, &mut data)?;
         assert_eq!(data[0][0], 57.);
@@ -291,10 +292,10 @@ mod tests {
 
         // But this classic should work...
         let op = ctx.op("geo:in | utm zone=32")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         ctx.apply(op, Fwd, &mut data)?;
-        assert!((data[0][0] - 691875.632139660884) < 1e-9);
-        assert!((data[0][1] - 6098907.825005002320) < 1e-9);
+        let expected = [691875.6321396609, 6098907.825005002];
+        assert_float_eq!(data[0].0, expected, abs_all <= 1e-9);
 
         Ok(())
     }

--- a/src/coordinate/set.rs
+++ b/src/coordinate/set.rs
@@ -277,7 +277,7 @@ mod tests {
     // Test the "impl<const N: usize> CoordinateSet for [Coor4D; N]"
     #[test]
     fn array() {
-        let mut operands = some_basic_coordinates();
+        let mut operands = some_basic_coor4dinates();
         assert_eq!(operands.len(), 2);
         assert_eq!(operands.is_empty(), false);
 
@@ -299,7 +299,7 @@ mod tests {
     // Test the "impl CoordinateSet for Vec<Coor4D>"
     #[test]
     fn vector() {
-        let mut operands = Vec::from(some_basic_coordinates());
+        let mut operands = Vec::from(some_basic_coor4dinates());
         assert_eq!(operands.len(), 2);
         assert_eq!(operands.is_empty(), false);
 
@@ -321,7 +321,7 @@ mod tests {
     // Test the "AngularUnits" conversion trait
     #[test]
     fn angular() {
-        let mut operands = some_basic_coordinates();
+        let mut operands = some_basic_coor2dinates();
         let cph = operands.get_coord(0);
 
         // Note the different usage patterns when using the AngularUnits trait with

--- a/src/inner_op/addone.rs
+++ b/src/inner_op/addone.rs
@@ -48,7 +48,7 @@ mod tests {
     fn addone() -> Result<(), Error> {
         let mut ctx = Minimal::default();
         let op = ctx.op("addone")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[1][0], 59.);
         ctx.apply(op, Fwd, &mut data)?;

--- a/src/inner_op/pipeline.rs
+++ b/src/inner_op/pipeline.rs
@@ -192,7 +192,7 @@ mod tests {
     fn pipeline() -> Result<(), Error> {
         let mut ctx = Minimal::default();
         let op = ctx.op("addone|addone|addone")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
 
         ctx.apply(op, Fwd, &mut data)?;
         assert_eq!(data[0][0], 58.);
@@ -203,7 +203,7 @@ mod tests {
         assert_eq!(data[1][0], 59.);
 
         let op = ctx.op("addone|addone inv|addone")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[1][0], 59.);
 
@@ -227,7 +227,7 @@ mod tests {
     #[test]
     fn push_pop() -> Result<(), Error> {
         let mut ctx = Minimal::default();
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor3dinates();
 
         // First we swap lat, lon by doing two independent pops
         let op = ctx.op("push v_2 v_1|addone|pop v_1|pop v_2")?;
@@ -254,14 +254,14 @@ mod tests {
 
         // Check inversion
         let op = ctx.op("push v_1 v_2|pop v_2 v_1 v_3")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor3dinates();
         assert_eq!(2, ctx.apply(op, Inv, &mut data)?);
         assert_eq!(data[0][0], 12.);
         assert_eq!(data[0][1], 0.);
 
         // Check omit_fwd
         let op = ctx.op("push v_1 v_2|pop v_2 v_1 v_3 omit_fwd")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor3dinates();
         assert_eq!(2, ctx.apply(op, Fwd, &mut data)?);
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[0][1], 12.);
@@ -271,7 +271,7 @@ mod tests {
 
         // Check omit_inv
         let op = ctx.op("push v_1 v_2 v_3 omit_inv|pop v_1 v_2")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor3dinates();
         assert_eq!(2, ctx.apply(op, Inv, &mut data)?);
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[0][1], 12.);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,21 @@ pub mod prelude {
     pub use crate::Direction::Inv;
     pub use crate::Error;
     #[cfg(test)]
-    pub fn some_basic_coordinates() -> [Coor4D; 2] {
+    pub fn some_basic_coor4dinates() -> [Coor4D; 2] {
         let copenhagen = Coor4D::raw(55., 12., 0., 0.);
         let stockholm = Coor4D::raw(59., 18., 0., 0.);
+        [copenhagen, stockholm]
+    }
+    #[cfg(test)]
+    pub fn some_basic_coor3dinates() -> [Coor3D; 2] {
+        let copenhagen = Coor3D::raw(55., 12., 0.);
+        let stockholm = Coor3D::raw(59., 18., 0.);
+        [copenhagen, stockholm]
+    }
+    #[cfg(test)]
+    pub fn some_basic_coor2dinates() -> [Coor2D; 2] {
+        let copenhagen = Coor2D::raw(55., 12.);
+        let stockholm = Coor2D::raw(59., 18.);
         [copenhagen, stockholm]
     }
 }

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -282,7 +282,7 @@ mod tests {
 
         // Check forward and inverse operation
         let op = ctx.op("addone")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         ctx.apply(op, Fwd, &mut data)?;
         assert_eq!(data[0][0], 56.);
         assert_eq!(data[1][0], 60.);
@@ -292,7 +292,7 @@ mod tests {
 
         // Also for an inverted operator: check forward and inverse operation
         let op = ctx.op("addone inv ")?;
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         ctx.apply(op, Fwd, &mut data)?;
         assert_eq!(data[0][0], 54.);
         assert_eq!(data[1][0], 58.);
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn pipeline() -> Result<(), Error> {
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         let mut ctx = Minimal::default();
         let op = ctx.op("addone|addone|addone")?;
 
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn macro_expansion() -> Result<(), Error> {
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         let mut ctx = Minimal::default();
         ctx.register_resource("sub:one", "addone inv");
         let op = ctx.op("addone|sub:one|addone")?;
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn macro_expansion_inverted() -> Result<(), Error> {
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         let mut ctx = Minimal::default();
         ctx.register_resource("sub:one", "addone inv");
         let op = ctx.op("addone|sub:one inv|addone")?;
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn macro_expansion_with_embedded_pipeline() -> Result<(), Error> {
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         let mut ctx = Minimal::default();
         ctx.register_resource("sub:three", "addone inv|addone inv|addone inv");
         let op = ctx.op("addone|sub:three")?;
@@ -403,7 +403,7 @@ mod tests {
 
     #[test]
     fn macro_expansion_with_defaults_provided() -> Result<(), Error> {
-        let mut data = some_basic_coordinates();
+        let mut data = some_basic_coor2dinates();
         let mut ctx = Minimal::default();
 
         // A macro providing a default value of 1 for the x parameter


### PR DESCRIPTION
Introduce the `assert_float_eq!` macro from the `float_eq` package, which give excellent diagnostics for floating point comparisons in multiple dimensions.

Also introduce 2D and 3D versions of the `some_basic_coordinates` function, to reduce the noise when using `assert_float_eq!` in tests.