### PR TITLE
Simplify ParsedParameters

### DIFF
--- a/src/context/minimal.rs
+++ b/src/context/minimal.rs
@@ -136,23 +136,23 @@ mod tests {
         ctx.register_resource("stupid:way", "addone | addone | addone inv");
         let op = ctx.op("stupid:way")?;
 
+        let steps = ctx.steps(op)?;
+        assert_eq!(steps.len(), 3);
+        assert_eq!(steps[0], "addone");
+        assert_eq!(steps[1], "addone");
+        assert_eq!(steps[2], "addone inv");
+
         let mut data = some_basic_coor2dinates();
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[1][0], 59.);
 
-        ctx.apply(op, Fwd, &mut data)?;
+        assert_eq!(2, ctx.apply(op, Fwd, &mut data)?);
         assert_eq!(data[0][0], 56.);
         assert_eq!(data[1][0], 60.);
 
         ctx.apply(op, Inv, &mut data)?;
         assert_eq!(data[0][0], 55.);
         assert_eq!(data[1][0], 59.);
-
-        let steps = ctx.steps(op)?;
-        assert_eq!(steps.len(), 3);
-        assert_eq!(steps[0], "addone");
-        assert_eq!(steps[1], "addone");
-        assert_eq!(steps[2], "addone inv");
 
         let params = ctx.params(op, 1)?;
         let ellps = params.ellps(0);
@@ -195,9 +195,9 @@ mod tests {
         // while ellps_? defaults to GRS80 - so they are there even though we havent
         // set them
         let params = ctx.params(op, 1)?;
-        let ellps = params.ellps[0];
+        let ellps = params.ellps(0);
         assert_eq!(ellps.semimajor_axis(), 6378137.);
-        assert_eq!(0., params.lat[0]);
+        assert_eq!(0., params.real("lat_0")?);
 
         // The zone id is found among the natural numbers (which here includes 0)
         let zone = params.natural("zone")?;
@@ -225,7 +225,7 @@ mod tests {
         let op = ctx.op("utm zone=32")?;
         let steps = ctx.steps(op)?;
         assert!(steps.len() == 1);
-        let ellps = ctx.params(op, 0)?.ellps[0];
+        let ellps = ctx.params(op, 0)?.ellps(0);
         let jac = Jacobian::new(
             &ctx,
             op,

--- a/src/inner_op/btmerc.rs
+++ b/src/inner_op/btmerc.rs
@@ -5,13 +5,13 @@ use crate::operator_authoring::*;
 
 // Forward transverse mercator, following Bowring (1989)
 fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
     let eps = ellps.second_eccentricity_squared();
-    let lat_0 = op.params.lat[0];
-    let lon_0 = op.params.lon[0];
-    let x_0 = op.params.x[0];
-    let y_0 = op.params.y[0];
-    let k_0 = op.params.k[0];
+    let lat_0 = op.params.lat(0).to_radians();
+    let lon_0 = op.params.lon(0).to_radians();
+    let x_0 = op.params.x(0);
+    let y_0 = op.params.y(0);
+    let k_0 = op.params.k(0);
 
     let mut successes = 0_usize;
     let n = operands.len();
@@ -53,13 +53,13 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
 
 // Inverse transverse mercator, following Bowring (1989)
 fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
     let eps = ellps.second_eccentricity_squared();
-    let lat_0 = op.params.lat[0];
-    let lon_0 = op.params.lon[0];
-    let x_0 = op.params.x[0];
-    let y_0 = op.params.y[0];
-    let k_0 = op.params.k[0];
+    let lat_0 = op.params.lat(0).to_radians();
+    let lon_0 = op.params.lon(0).to_radians();
+    let x_0 = op.params.x(0);
+    let y_0 = op.params.y(0);
+    let k_0 = op.params.k(0);
 
     let mut successes = 0_usize;
     let n = operands.len();
@@ -134,22 +134,24 @@ pub fn utm(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
     }
 
     // The scaling factor is 0.9996 by definition of UTM
-    params.k[0] = 0.9996;
+    params.real.insert("k_0", 0.9996);
 
     // The center meridian is determined by the zone
-    params.lon[0] = (-183. + 6. * zone as f64).to_radians();
+    params
+        .real
+        .insert("lon_0", -183. + 6. * zone as f64);
 
     // The base parallel is by definition the equator
-    params.lat[0] = 0.0;
+    params.real.insert("lat_0", 0.);
 
     // The false easting is 500000 m by definition of UTM
-    params.x[0] = 500000.0;
+    params.real.insert("x_0", 500_000.);
 
     // The false northing is 0 m by definition of UTM
-    params.y[0] = 0.0;
+    params.real.insert("y_0", 0.);
     // or 10_000_000 m if using the southern aspect
     if params.boolean("south") {
-        params.y[0] = 10_000_000.0;
+        params.real.insert("y_0", 10_000_000.0);
     }
 
     let descriptor = OpDescriptor::new(def, InnerOp(fwd), Some(InnerOp(inv)));

--- a/src/inner_op/cart.rs
+++ b/src/inner_op/cart.rs
@@ -6,9 +6,10 @@ use crate::operator_authoring::*;
 fn cart_fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     let n = operands.len();
     let mut successes = 0;
+    let ellps = op.params.ellps(0);
     for i in 0..n {
         let mut coord = operands.get_coord(i);
-        coord = op.params.ellps[0].cartesian(&coord);
+        coord = ellps.cartesian(&coord);
         if !coord.0.iter().any(|c| c.is_nan()) {
             successes += 1;
         }
@@ -20,20 +21,21 @@ fn cart_fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> us
 // ----- I N V E R S E --------------------------------------------------------------
 
 fn cart_inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
+    let ellps = op.params.ellps(0);
     // eccentricity squared, Fukushima's E, Claessens' c3 = 1-c2`
-    let es = op.params.ellps[0].eccentricity_squared();
+    let es = ellps.eccentricity_squared();
     // semiminor axis
-    let b = op.params.ellps[0].semiminor_axis();
+    let b = ellps.semiminor_axis();
     // semimajor axis
-    let a = op.params.ellps[0].semimajor_axis();
+    let a = ellps.semimajor_axis();
     // reciproque of a
-    let ra = 1. / op.params.ellps[0].semimajor_axis();
+    let ra = 1. / ellps.semimajor_axis();
     // aspect ratio, b/a: Fukushima's ec, Claessens' c4
     let ar = b * ra;
     // 1.5 times the fourth power of the eccentricity
     let ce4 = 1.5 * es * es;
     // if we're closer than this to the Z axis, we force latitude to one of the poles
-    let cutoff = op.params.ellps[0].semimajor_axis() * 1e-16;
+    let cutoff = ellps.semimajor_axis() * 1e-16;
 
     let n = operands.len();
     let mut successes = 0;

--- a/src/inner_op/curvature.rs
+++ b/src/inner_op/curvature.rs
@@ -6,7 +6,7 @@ use crate::operator_authoring::*;
 fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     let n = operands.len();
     let sliced = 0..n;
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
 
     let prime = op.params.boolean("prime");
     let meridional = op.params.boolean("meridian");
@@ -114,6 +114,11 @@ pub fn new(parameters: &RawParameters, ctx: &dyn Context) -> Result<Op, Error> {
             "curvature: must specify exactly one of flags prime/meridian/gaussian/mean/azimuthal"
                 .to_string(),
         ));
+    }
+
+    // Check that we have a proper ellipsoid
+    if op.params.text("ellps").is_ok() {
+        let _ = Ellipsoid::named(op.params.text("ellps")?.as_str())?;
     }
 
     Ok(op)

--- a/src/inner_op/geodesic.rs
+++ b/src/inner_op/geodesic.rs
@@ -4,7 +4,7 @@ use crate::operator_authoring::*;
 // ----- F O R W A R D -----------------------------------------------------------------
 
 fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
 
     let n = operands.len();
     let sliced = 0..n;
@@ -35,7 +35,7 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
 // ----- I N V E R S E -----------------------------------------------------------------
 
 fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
     let reversible = op.params.boolean("reversible");
 
     let n = operands.len();

--- a/src/inner_op/latitude.rs
+++ b/src/inner_op/latitude.rs
@@ -7,7 +7,7 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     let mut successes = 0_usize;
     let n = operands.len();
     let sliced = 0..n;
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
 
     if op.params.boolean("geocentric") {
         for i in sliced {
@@ -66,7 +66,7 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
 fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     let mut successes = 0_usize;
     let n = operands.len();
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
 
     if op.params.boolean("geocentric") {
         for i in 0..n {
@@ -137,7 +137,7 @@ pub const GAMUT: [OpParameter; 8] = [
 
 pub fn new(parameters: &RawParameters, ctx: &dyn Context) -> Result<Op, Error> {
     let mut op = Op::plain(parameters, InnerOp(fwd), Some(InnerOp(inv)), &GAMUT, ctx)?;
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
 
     let mut number_of_flags = 0_usize;
     if op.params.boolean("geocentric") {

--- a/src/inner_op/merc.rs
+++ b/src/inner_op/merc.rs
@@ -4,13 +4,13 @@ use crate::operator_authoring::*;
 // ----- F O R W A R D -----------------------------------------------------------------
 
 fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
     let a = ellps.semimajor_axis();
-    let k_0 = op.params.k[0];
-    let x_0 = op.params.x[0];
-    let y_0 = op.params.y[0];
-    let lat_0 = op.params.lat[0];
-    let lon_0 = op.params.lon[0];
+    let k_0 = op.params.k(0);
+    let x_0 = op.params.x(0);
+    let y_0 = op.params.y(0);
+    let lat_0 = op.params.lat(0);
+    let lon_0 = op.params.lon(0);
 
     let mut successes = 0_usize;
     let length = operands.len();
@@ -33,13 +33,13 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
 // ----- I N V E R S E -----------------------------------------------------------------
 
 fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
     let a = ellps.semimajor_axis();
-    let k_0 = op.params.k[0];
-    let x_0 = op.params.x[0];
-    let y_0 = op.params.y[0];
-    let lat_0 = op.params.lat[0];
-    let lon_0 = op.params.lon[0];
+    let k_0 = op.params.k(0);
+    let x_0 = op.params.x(0);
+    let y_0 = op.params.y(0);
+    let lat_0 = op.params.lat(0);
+    let lon_0 = op.params.lon(0);
 
     let mut successes = 0_usize;
     let length = operands.len();
@@ -80,7 +80,7 @@ pub const GAMUT: [OpParameter; 8] = [
 pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> {
     let def = &parameters.definition;
     let mut params = ParsedParameters::new(parameters, &GAMUT)?;
-    let ellps = params.ellps[0];
+    let ellps = params.ellps(0);
 
     let lat_ts = params.real("lat_ts")?;
     if lat_ts.abs() > 90. {
@@ -92,7 +92,8 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
     // lat_ts trumps k_0
     if lat_ts != 0.0 {
         let sc = lat_ts.to_radians().sin_cos();
-        params.k[0] = sc.1 / (1. - ellps.eccentricity_squared() * sc.0 * sc.0).sqrt()
+        let k_0 = sc.1 / (1. - ellps.eccentricity_squared() * sc.0 * sc.0).sqrt();
+        params.real.insert("k_0", k_0);
     }
 
     let descriptor = OpDescriptor::new(def, InnerOp(fwd), Some(InnerOp(inv)));

--- a/src/inner_op/molodensky.rs
+++ b/src/inner_op/molodensky.rs
@@ -25,7 +25,7 @@ fn common(
     operands: &mut dyn CoordinateSet,
     direction: Direction,
 ) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
     let a = ellps.semimajor_axis();
     let f = ellps.flattening();
     let es = ellps.eccentricity_squared();
@@ -100,8 +100,8 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
     let def = &parameters.definition;
     let mut params = ParsedParameters::new(parameters, &GAMUT)?;
 
-    let ellps_0 = params.ellps[0];
-    let ellps_1 = params.ellps[1];
+    let ellps_0 = params.ellps(0);
+    let ellps_1 = params.ellps(1);
 
     // We may use `ellps, da, df`, to parameterize the op, but `ellps_0, ellps_1`
     // is a more likely set of parameters to come across in real life.

--- a/src/inner_op/pipeline.rs
+++ b/src/inner_op/pipeline.rs
@@ -194,7 +194,7 @@ mod tests {
         let op = ctx.op("addone|addone|addone")?;
         let mut data = some_basic_coor2dinates();
 
-        ctx.apply(op, Fwd, &mut data)?;
+        assert_eq!(2, ctx.apply(op, Fwd, &mut data)?);
         assert_eq!(data[0][0], 58.);
         assert_eq!(data[1][0], 62.);
 

--- a/src/inner_op/webmerc.rs
+++ b/src/inner_op/webmerc.rs
@@ -6,7 +6,7 @@ use std::f64::consts::FRAC_PI_4;
 // ----- F O R W A R D -----------------------------------------------------------------
 
 fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
     let a = ellps.semimajor_axis();
 
     let mut successes = 0_usize;
@@ -30,7 +30,7 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
 // ----- I N V E R S E -----------------------------------------------------------------
 
 fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let ellps = op.params.ellps[0];
+    let ellps = op.params.ellps(0);
     let a = ellps.semimajor_axis();
 
     let mut successes = 0_usize;
@@ -80,6 +80,7 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use float_eq::assert_float_eq;
 
     #[test]
     fn webmerc() -> Result<(), Error> {
@@ -102,14 +103,13 @@ mod tests {
         let mut operands = geo.clone();
         ctx.apply(op, Fwd, &mut operands)?;
         for i in 0..operands.len() {
-            assert!(operands[i].hypot2(&projected[i]) < 1e-8);
+            assert_float_eq!(operands[i].0, projected[i].0, abs_all <= 1e-8);
         }
 
         // Roundtrip
         ctx.apply(op, Inv, &mut operands)?;
         for i in 0..operands.len() {
-            dbg!(operands[0].to_geo());
-            assert!(operands[i].hypot2(&geo[i]) < 2e-9);
+            assert_float_eq!(operands[i].0, geo[i].0, abs_all <= 2e-9);
         }
 
         Ok(())

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -67,7 +67,19 @@ impl Op {
         _ctx: &dyn Context,
     ) -> Result<Op, Error> {
         let def = parameters.definition.as_str();
-        let params = ParsedParameters::new(parameters, gamut)?;
+        let mut params = ParsedParameters::new(parameters, gamut)?;
+
+        // Convert lat_{0..4} and lon_{0..4} to radians
+        for i in ["lat_0", "lat_1", "lat_2", "lat_3"] {
+            let lat = *params.real.get(i).unwrap_or(&0.);
+            params.real.insert(i, lat);
+        }
+
+        for i in ["lon_0", "lon_1", "lon_2", "lon_3"] {
+            let lon = *params.real.get(i).unwrap_or(&0.);
+            params.real.insert(i, lon);
+        }
+
         let descriptor = OpDescriptor::new(def, fwd, inv);
         let steps = Vec::<Op>::new();
         let id = OpHandle::new();

--- a/src/op/parameter.rs
+++ b/src/op/parameter.rs
@@ -12,7 +12,7 @@
 ///
 /// For a given operation, the union of the sets of its required and optional
 /// parameters is called the *gamut* of the operation.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum OpParameter {
     /// A flag is a boolean that is true if present, false if not
     Flag { key: &'static str },


### PR DESCRIPTION
Remove the special treatment of x_0.., y_0.., lat_0.., lon_0.. in ParsedParameters, so all parameters are treated identically.

The accessors x, y, lat, lon and ellps are still available.

This may make the code slightly slower, but also more accessible