### PR TITLE
Add partial support PROJ ellipsoid definitions

### DIFF
--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -454,6 +454,20 @@ mod tests {
             "step step=quickstep | utm inv zone=32 | stepwise | quickstep"
         );
 
+        // Invert the entire pipeline, turning "zone 32-to-zone 33" into "zone 33-to-zone 32"
+        // Also throw a few additional spanners in the works, in the form of some ugly, but
+        // PROJ-accepted, syntactical abominations
+        assert_eq!(
+            parse_proj("inv ellps=intl proj=pipeline ugly=syntax +step inv proj=utm zone=32 step proj=utm zone=33")?,
+            "utm inv ellps=intl ugly=syntax zone=33 | utm ellps=intl ugly=syntax zone=32"
+        );
+
+        // Check for the proper inversion of directional omissions
+        assert_eq!(
+            parse_proj("proj=pipeline inv   +step   omit_fwd inv proj=utm zone=32   step   omit_inv proj=utm zone=33")?,
+            "utm inv omit_fwd zone=33 | utm omit_inv zone=32"
+        );
+
         // Nested pipelines are not supported...
 
         // Nested pipelines in PROJ requires an `init=` indirection
@@ -488,20 +502,6 @@ mod tests {
 
     #[test]
     fn tidy_proj() -> Result<(), Error> {
-        // Invert the entire pipeline, turning "zone 32-to-zone 33" into "zone 33-to-zone 32"
-        // Also throw a few additional spanners in the works, in the form of some ugly, but
-        // PROJ-accepted, syntactical abominations
-        assert_eq!(
-            parse_proj("inv ellps=intl proj=pipeline ugly=syntax +step inv proj=utm zone=32 step proj=utm zone=33")?,
-            "utm inv ellps=intl ugly=syntax zone=33 | utm ellps=intl ugly=syntax zone=32"
-        );
-
-        // Check for the proper inversion of directional omissions
-        assert_eq!(
-            parse_proj("proj=pipeline inv   +step   omit_fwd inv proj=utm zone=32   step   omit_inv proj=utm zone=33")?,
-            "utm inv omit_fwd zone=33 | utm omit_inv zone=32"
-        );
-
         // Ellipsoid defined with a and rf parameters instead of ellps
         assert_eq!(
                 parse_proj("+proj=pipeline +step +inv +proj=tmerc +a=6378249.145 +rf=293.465 +step +proj=step2")?,

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -170,14 +170,14 @@ where
 /// ## Known differences between PROJ and Rust Geodesy definitions:
 ///
 /// ## Ellipsoid definitions
-/// - Geodesy only supports a limited set of builtin ellipsoids OR ellps=a,rf.
-/// - PROJ has richer ellipsoid support which *parse_proj* provides partial support for.
+/// - Geodesy only supports a limited set of builtin ellipsoids OR or definition
+/// via semi-major and reverse-flattening parameters  `ellps=a,rf`.
+/// - PROJ has [richer ellipsoid](https://proj.org/en/9.3/usage/ellipsoids.html#ellipsoid-size-parameters)
+/// support which *parse_proj* provides partial support for.
 /// - Specifically if an ellipsoid is defined via `a` and `rf` parameters, *parse_proj*
 /// will redefine them as `ellps=a,rf` and remove the `a` and `rf` parameters.
-/// - A known limitation is that if an ellipsoid is defined via `ellps` but also
-/// attempts to modify the builtin with additional `a` or `rf` parameters. In this case
-/// *parse_proj* will do nothing and rely on the operator instantiation to fail due to
-/// unknown parameters.
+/// - All other cases supported by PROJ are NOT handled by *parse_proj* and will
+/// fail when instantiating the operator.
 ///
 /// ## Scaling via `k` parameter
 /// - PROJ still supports the deprecated `k` parameter. Most output from `projinfo` will

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -182,7 +182,7 @@ where
 /// ## Scaling via `k` parameter
 /// - PROJ still supports the deprecated `k` parameter. Most output from `projinfo` will
 /// have the scaling defined as `k` instead of `k_0`.
-/// - *parse_proj* will replace `k` with `k_0` when ever it is encountered.
+/// - *parse_proj* will replace `k` with `k_0` whenever it is encountered.
 ///
 pub fn parse_proj(definition: &str) -> Result<String, Error> {
     // Impose some line ending sanity and remove the PROJ '+' prefix
@@ -502,7 +502,7 @@ mod tests {
 
     #[test]
     fn tidy_proj() -> Result<(), Error> {
-        // Ellipsoid defined with a and rf parameters instead of ellps
+        // Ellipsoid defined with `a` and `rf` parameters instead of ellps
         assert_eq!(
                 parse_proj("+proj=pipeline +step +inv +proj=tmerc +a=6378249.145 +rf=293.465 +step +proj=step2")?,
                 "tmerc inv ellps=6378249.145,293.465 | step2"
@@ -511,7 +511,7 @@ mod tests {
         // Ellipsoid is defined with a builtin
         assert_eq!(parse_proj("+proj=tmerc +ellps=GRS80")?, "tmerc ellps=GRS80");
 
-        // Ellipsoid is defined with a builtin but is modified by a or rf
+        // Ellipsoid is defined with a builtin but is modified by `a` or `rf`
         // Note we don't remove `a` here even though this modification is not supported in RG
         // it's expected to fail in the operator instantiation
         assert_eq!(
@@ -519,7 +519,7 @@ mod tests {
             "tmerc ellps=GRS80 a=1"
         );
 
-        // Replace occurances of k= with k_0=
+        // Replace occurrences of `k=` with `k_0=`
         assert_eq!(parse_proj("+proj=tmerc +k=1.5")?, "tmerc k_0=1.5");
 
         Ok(())

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -167,21 +167,22 @@ where
 /// second that Rust Geodesy does not support init-files. Hence no support for
 /// any kind of nesting here.
 ///
-/// Known differences between PROJ and Rust Geodesy definitions:
-/// #Ellipsoid definitions
-/// - Geodesy only supports a limited set of named ellipsoids OR ellps=a,rf.
-/// - PROJ has richer ellipsoid support which {parse_proj} provides partial support for.
-/// - Specifically if an ellipsoid is defined via `a` and `rf` parameters, {parse_proj}
+/// ## Known differences between PROJ and Rust Geodesy definitions:
+///
+/// ## Ellipsoid definitions
+/// - Geodesy only supports a limited set of builtin ellipsoids OR ellps=a,rf.
+/// - PROJ has richer ellipsoid support which *parse_proj* provides partial support for.
+/// - Specifically if an ellipsoid is defined via `a` and `rf` parameters, *parse_proj*
 /// will redefine them as `ellps=a,rf` and remove the `a` and `rf` parameters.
 /// - A known limitation is that if an ellipsoid is defined via `ellps` but also
 /// attempts to modify the builtin with additional `a` or `rf` parameters. In this case
-/// {parse_proj} will do nothing and rely on the operator instantiation to fail due to
+/// *parse_proj* will do nothing and rely on the operator instantiation to fail due to
 /// unknown parameters.
 ///
-/// # Scaling via `k` parameter
+/// ## Scaling via `k` parameter
 /// - PROJ still supports the deprecated `k` parameter. Most output from `projinfo` will
 /// have the scaling defined as `k` instead of `k_0`.
-/// - {parse_proj} will replace `k` with `k_0` when ever it is encountered.
+/// - *parse_proj* will replace `k` with `k_0` when ever it is encountered.
 ///
 pub fn parse_proj(definition: &str) -> Result<String, Error> {
     // Impose some line ending sanity and remove the PROJ '+' prefix


### PR DESCRIPTION
PROJ has rich support for defining an ellipsoid in a proj string. RG only supports the builtins or definitions via `ellps=a,rf` syntax. This PR adds support for reworking `a` and `rf` parameters in a proj string to `ellps=a,rf`. This support is added to `parse_proj` as it felt like the cleanest approach. 

I opted for ignoring ALL other cases as they seemed more difficult to fix. I've added some documentation to `parse_proj` to indicate to users what they can expect. 

I've also tacked on a small tidyup to proj strings whereby a scaling `k` parameter gets converted to `k_0`. 


closes #61