### PR TITLE
Prototype multi grid support

### DIFF
--- a/src/context/minimal.rs
+++ b/src/context/minimal.rs
@@ -1,5 +1,5 @@
 use crate::authoring::*;
-use std::path::PathBuf;
+use std::{path::PathBuf, rc::Rc};
 
 // ----- T H E   M I N I M A L   P R O V I D E R ---------------------------------------
 
@@ -114,7 +114,7 @@ impl Context for Minimal {
     }
 
     /// Access grid resources by identifier
-    fn get_grid(&self, _name: &str) -> Result<Grid, Error> {
+    fn get_grid(&self, _name: &str) -> Result<Rc<dyn GridTrait>, Error> {
         Err(Error::General(
             "Grid access by identifier not supported by the Minimal context provider",
         ))

--- a/src/context/minimal.rs
+++ b/src/context/minimal.rs
@@ -1,5 +1,5 @@
 use crate::authoring::*;
-use std::{path::PathBuf, rc::Rc};
+use std::{path::PathBuf, sync::Arc};
 
 // ----- T H E   M I N I M A L   P R O V I D E R ---------------------------------------
 
@@ -114,7 +114,7 @@ impl Context for Minimal {
     }
 
     /// Access grid resources by identifier
-    fn get_grid(&self, _name: &str) -> Result<Rc<dyn Grid>, Error> {
+    fn get_grid(&self, _name: &str) -> Result<Arc<dyn Grid>, Error> {
         Err(Error::General(
             "Grid access by identifier not supported by the Minimal context provider",
         ))

--- a/src/context/minimal.rs
+++ b/src/context/minimal.rs
@@ -114,7 +114,7 @@ impl Context for Minimal {
     }
 
     /// Access grid resources by identifier
-    fn get_grid(&self, _name: &str) -> Result<Rc<dyn GridTrait>, Error> {
+    fn get_grid(&self, _name: &str) -> Result<Rc<dyn Grid>, Error> {
         Err(Error::General(
             "Grid access by identifier not supported by the Minimal context provider",
         ))

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::authoring::*;
 pub mod minimal;
 pub use minimal::Minimal;
@@ -52,7 +54,7 @@ pub trait Context {
     fn get_blob(&self, name: &str) -> Result<Vec<u8>, Error>;
 
     /// Access grid resources by identifier
-    fn get_grid(&self, name: &str) -> Result<Grid, Error>;
+    fn get_grid(&self, name: &str) -> Result<Rc<dyn GridTrait>, Error>;
 }
 
 /// Help context providers provide canonically named, built in coordinate adaptors

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::authoring::*;
 pub mod minimal;
@@ -54,7 +54,7 @@ pub trait Context {
     fn get_blob(&self, name: &str) -> Result<Vec<u8>, Error>;
 
     /// Access grid resources by identifier
-    fn get_grid(&self, name: &str) -> Result<Rc<dyn Grid>, Error>;
+    fn get_grid(&self, name: &str) -> Result<Arc<dyn Grid>, Error>;
 }
 
 /// Help context providers provide canonically named, built in coordinate adaptors

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -54,7 +54,7 @@ pub trait Context {
     fn get_blob(&self, name: &str) -> Result<Vec<u8>, Error>;
 
     /// Access grid resources by identifier
-    fn get_grid(&self, name: &str) -> Result<Rc<dyn GridTrait>, Error>;
+    fn get_grid(&self, name: &str) -> Result<Rc<dyn Grid>, Error>;
 }
 
 /// Help context providers provide canonically named, built in coordinate adaptors

--- a/src/context/plain.rs
+++ b/src/context/plain.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "with_plain")]
 use crate::authoring::*;
-use std::{path::PathBuf, rc::Rc};
+use std::{path::PathBuf, sync::Arc};
 
 // ----- T H E   P L A I N   C O N T E X T ---------------------------------------------
 
@@ -197,7 +197,7 @@ impl Context for Plain {
     }
 
     /// Access grid resources by identifier
-    fn get_grid(&self, name: &str) -> Result<Rc<dyn Grid>, Error> {
+    fn get_grid(&self, name: &str) -> Result<Arc<dyn Grid>, Error> {
         let n = PathBuf::from(name);
         let ext = n
             .extension()
@@ -211,7 +211,7 @@ impl Context for Plain {
             let Ok(grid) = std::fs::read(path) else {
                 continue;
             };
-            let grid = Rc::new(BaseGrid::gravsoft(&grid)?);
+            let grid = Arc::new(BaseGrid::gravsoft(&grid)?);
             return Ok(grid);
         }
         Err(Error::NotFound(name.to_string(), ": Blob".to_string()))

--- a/src/context/plain.rs
+++ b/src/context/plain.rs
@@ -197,7 +197,7 @@ impl Context for Plain {
     }
 
     /// Access grid resources by identifier
-    fn get_grid(&self, name: &str) -> Result<Rc<dyn GridTrait>, Error> {
+    fn get_grid(&self, name: &str) -> Result<Rc<dyn Grid>, Error> {
         let n = PathBuf::from(name);
         let ext = n
             .extension()
@@ -211,7 +211,7 @@ impl Context for Plain {
             let Ok(grid) = std::fs::read(path) else {
                 continue;
             };
-            let grid = Rc::new(Grid::gravsoft(&grid)?);
+            let grid = Rc::new(BaseGrid::gravsoft(&grid)?);
             return Ok(grid);
         }
         Err(Error::NotFound(name.to_string(), ": Blob".to_string()))

--- a/src/context/plain.rs
+++ b/src/context/plain.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "with_plain")]
 use crate::authoring::*;
-use std::path::PathBuf;
+use std::{path::PathBuf, rc::Rc};
 
 // ----- T H E   P L A I N   C O N T E X T ---------------------------------------------
 
@@ -197,7 +197,7 @@ impl Context for Plain {
     }
 
     /// Access grid resources by identifier
-    fn get_grid(&self, name: &str) -> Result<Grid, Error> {
+    fn get_grid(&self, name: &str) -> Result<Rc<dyn GridTrait>, Error> {
         let n = PathBuf::from(name);
         let ext = n
             .extension()
@@ -211,7 +211,8 @@ impl Context for Plain {
             let Ok(grid) = std::fs::read(path) else {
                 continue;
             };
-            return Grid::gravsoft(&grid);
+            let grid = Rc::new(Grid::gravsoft(&grid)?);
+            return Ok(grid);
         }
         Err(Error::NotFound(name.to_string(), ": Blob".to_string()))
     }

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -13,7 +13,7 @@ pub trait Grid: Debug {
 // NOTE: Should this be renamed PlainGrid? Then rename the trait to Grid?
 /// Grid characteristics and interpolation.
 ///
-/// The actual grid may be part of the `Grid` struct, or
+/// The actual grid may be part of the `BaseGrid` struct, or
 /// provided externally (presumably by a [Context](crate::Context)).
 ///
 /// In principle grid format agnostic, but includes a parser for

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -10,7 +10,6 @@ pub trait Grid: Debug {
     fn interpolation(&self, coord: &Coor4D, grid: Option<&[f32]>) -> Coor4D;
 }
 
-// NOTE: Should this be renamed PlainGrid? Then rename the trait to Grid?
 /// Grid characteristics and interpolation.
 ///
 /// The actual grid may be part of the `BaseGrid` struct, or

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -75,6 +75,10 @@ impl Grid for BaseGrid {
     // leads to a significantly larger code base, much harder to maintain and
     // comprehend.
     fn interpolation(&self, coord: &Coor4D, grid: Option<&[f32]>) -> Option<Coor4D> {
+        if !self.contains(*coord) {
+            return None;
+        };
+
         let grid = grid.unwrap_or(&self.grid);
 
         // The interpolation coordinate relative to the grid origin

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -6,9 +6,11 @@ use std::{fmt::Debug, io::BufRead};
 pub trait GridTrait: Debug {
     fn bands(&self) -> usize;
     fn contains(&self, position: Coor4D) -> bool;
+    // NOTE: `grid` is included for backwards compatibility but could be removed
     fn interpolation(&self, coord: &Coor4D, grid: Option<&[f32]>) -> Coor4D;
 }
 
+// NOTE: Should this be renamed PlainGrid? Then rename the trait to Grid?
 /// Grid characteristics and interpolation.
 ///
 /// The actual grid may be part of the `Grid` struct, or
@@ -37,7 +39,7 @@ impl GridTrait for Grid {
     fn bands(&self) -> usize {
         self.bands
     }
-    // Implement the methods of the GridTrait trait for the Grid struct here
+
     /// Determine whether a given coordinate falls within the grid borders.
     /// "On the border" qualifies as within.
     fn contains(&self, position: Coor4D) -> bool {

--- a/src/inner_op/deformation.rs
+++ b/src/inner_op/deformation.rs
@@ -233,8 +233,8 @@ pub fn new(parameters: &RawParameters, ctx: &dyn Context) -> Result<Op, Error> {
         ));
     }
 
-    let grid_file_name = params.text("grids")?;
-    for grid_name in grid_file_name.split(',') {
+    let grid_names = params.text("grids")?;
+    for grid_name in grid_names.split(',') {
         let grid = ctx.get_grid(grid_name)?;
         let n = grid.bands();
         if n != 3 {

--- a/src/inner_op/deformation.rs
+++ b/src/inner_op/deformation.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 /// Kinematic datum shift using a 3D deformation model in ENU-space.
 ///
 /// Based on Kristian Evers' implementation of the
@@ -120,7 +118,7 @@ use crate::authoring::*;
 // ----- F O R W A R D --------------------------------------------------------------
 
 fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let grids = &op.params.get_grids().unwrap();
+    let grids = &op.params.grids;
     let mut successes = 0_usize;
     let n = operands.len();
 
@@ -167,7 +165,7 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
 // ----- I N V E R S E --------------------------------------------------------------
 
 fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
-    let grids = &op.params.get_grids().unwrap();
+    let grids = &op.params.grids;
     let mut successes = 0_usize;
     let n = operands.len();
 
@@ -236,7 +234,6 @@ pub fn new(parameters: &RawParameters, ctx: &dyn Context) -> Result<Op, Error> {
     }
 
     let grid_file_name = params.text("grids")?;
-    let mut grids = Vec::<Rc<dyn GridTrait>>::new();
     for grid_name in grid_file_name.split(',') {
         let grid = ctx.get_grid(grid_name)?;
         let n = grid.bands();
@@ -247,9 +244,8 @@ pub fn new(parameters: &RawParameters, ctx: &dyn Context) -> Result<Op, Error> {
                 found: n.to_string(),
             });
         }
-        grids.push(grid);
+        params.grids.push(grid);
     }
-    params.set_grids(grids);
 
     let fwd = InnerOp(fwd);
     let inv = InnerOp(inv);
@@ -301,7 +297,7 @@ mod tests {
     #[test]
     fn deformation() -> Result<(), Error> {
         // Context and data
-        let mut ctx = Minimal::default();
+        let mut ctx = Plain::default();
         let cph = Coor4D::geo(55., 12., 0., 0.);
         let test_deformation = include_str!("../../geodesy/deformation/test.deformation");
 

--- a/src/inner_op/deformation.rs
+++ b/src/inner_op/deformation.rs
@@ -174,7 +174,7 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     let ellps = op.params.ellps(0);
     let raw = op.params.boolean("raw");
 
-    for grid in grids.iter() {
+    for grid in grids.iter().rev() {
         // Datum shift
         for i in 0..n {
             let cart = operands.get_coord(i);

--- a/src/inner_op/deformation.rs
+++ b/src/inner_op/deformation.rs
@@ -305,7 +305,7 @@ mod tests {
         ctx.register_resource("test.deformation", test_deformation);
 
         let buf = ctx.get_blob("test.deformation")?;
-        let grid = Grid::gravsoft(&buf)?;
+        let grid = BaseGrid::gravsoft(&buf)?;
 
         // Velocity in the ENU space
         let v = grid.interpolation(&cph, None);

--- a/src/inner_op/deformation.rs
+++ b/src/inner_op/deformation.rs
@@ -165,6 +165,7 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
         }
 
         if use_null_grid {
+            successes += 1;
             continue;
         }
 
@@ -224,6 +225,7 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
         }
 
         if use_null_grid {
+            successes += 1;
             continue;
         }
 

--- a/src/inner_op/gridshift.rs
+++ b/src/inner_op/gridshift.rs
@@ -78,7 +78,7 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
                         t = t - d;
                         // i.e. d.dot(d).sqrt() < 1e-10
                         if d.dot(d) < 1e-20 {
-                            break;
+                            break 'iterate;
                         }
                         continue 'iterate;
                     }

--- a/src/inner_op/gridshift.rs
+++ b/src/inner_op/gridshift.rs
@@ -43,7 +43,7 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     let mut successes = 0_usize;
     let n = operands.len();
 
-    for grid in grids.iter() {
+    for grid in grids.iter().rev() {
         // Geoid
         if grid.bands() == 1 {
             for i in 0..n {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub mod prelude {
 pub mod authoring {
     pub use crate::prelude::*;
 
+    pub use crate::grid::GridTrait;
     pub use crate::math::*;
     pub use crate::Grid;
     pub use crate::InnerOp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,9 @@ pub mod prelude {
 pub mod authoring {
     pub use crate::prelude::*;
 
-    pub use crate::grid::Grid;
+    pub use crate::grid::BaseGrid;
     pub use crate::math::*;
-    pub use crate::GridTrait;
+    pub use crate::Grid;
     pub use crate::InnerOp;
     pub use crate::Op;
     pub use crate::OpConstructor;
@@ -182,7 +182,7 @@ pub use crate::token::Tokenize;
 pub use crate::token::parse_proj;
 
 // The lower level data types, mostly use in the extended prelude 'authoring'
-pub use crate::grid::GridTrait;
+pub use crate::grid::Grid;
 pub use crate::inner_op::InnerOp;
 pub use crate::inner_op::OpConstructor;
 pub use crate::op::Op;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,9 @@ pub mod prelude {
 pub mod authoring {
     pub use crate::prelude::*;
 
-    pub use crate::grid::GridTrait;
+    pub use crate::grid::Grid;
     pub use crate::math::*;
-    pub use crate::Grid;
+    pub use crate::GridTrait;
     pub use crate::InnerOp;
     pub use crate::Op;
     pub use crate::OpConstructor;
@@ -182,7 +182,7 @@ pub use crate::token::Tokenize;
 pub use crate::token::parse_proj;
 
 // The lower level data types, mostly use in the extended prelude 'authoring'
-pub use crate::grid::Grid;
+pub use crate::grid::GridTrait;
 pub use crate::inner_op::InnerOp;
 pub use crate::inner_op::OpConstructor;
 pub use crate::op::Op;

--- a/src/op/parsed_parameters.rs
+++ b/src/op/parsed_parameters.rs
@@ -43,13 +43,17 @@ pub struct ParsedParameters {
     pub integer: BTreeMap<&'static str, i64>,
     pub real: BTreeMap<&'static str, f64>,
     pub series: BTreeMap<&'static str, Vec<f64>>,
-    pub grids: BTreeMap<&'static str, Rc<dyn GridTrait>>,
     pub text: BTreeMap<&'static str, String>,
     pub texts: BTreeMap<&'static str, Vec<String>>,
     pub uuid: BTreeMap<&'static str, uuid::Uuid>,
     pub fourier_coefficients: BTreeMap<&'static str, FourierCoefficients>,
     pub ignored: Vec<String>,
     pub given: BTreeMap<String, String>,
+
+    // Pointers to the grids required by the operator
+    // They should be inserted in the order they appear in the definition
+    // NOTE: We may want to consider use `Arc` instead of `Rc` here for concurrency reasons
+    pub grids: Vec<Rc<dyn GridTrait>>,
 }
 
 // Accessors
@@ -116,39 +120,6 @@ impl ParsedParameters {
         // If none of them existed, i.e. no defaults were given, we return the general default
         Ellipsoid::default()
     }
-    /// Returns the grid(s) associated with the operator
-    /// (typically a single grid, but some operators may
-    /// use multiple grids) which are provided as a Vec<&dyn GridTrait>
-    /// in the order they appear in the `grids` parameter.
-    pub fn get_grids(&self) -> Result<Vec<&Rc<dyn GridTrait>>, Error> {
-        //
-        if let Some(names) = self.text.get("grids") {
-            let grids = names
-                .split(",")
-                .map(|n| {
-                    self.grids.get(n).ok_or(Error::General(
-                        "Grid Not found, did you forget to set it with set_grid?",
-                    ))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            Ok(grids)
-        } else {
-            return Err(Error::MissingParam("grids".to_string()));
-        }
-    }
-
-    /// Construct and set grids required by this parameter
-    /// Operators that require a grid should get and create them in Inner_Op::new()
-    /// and then set them here. Typically the Context will have a way of loading a raw grid
-    pub fn set_grids(&mut self, grid: Vec<Rc<dyn GridTrait>>) {
-        if let Some(names) = self.text.get("grids") {
-            let names = names.split(",").collect::<Vec<_>>();
-            for (i, name) in names.iter().enumerate() {
-                self.grids.insert(name, grid[i].clone());
-            }
-        }
-    }
     pub fn k(&self, index: usize) -> f64 {
         *(self.real.get(&format!("k_{index}")[..]).unwrap_or(&1.))
     }
@@ -180,7 +151,7 @@ impl ParsedParameters {
         let mut series = BTreeMap::<&'static str, Vec<f64>>::new();
         let mut text = BTreeMap::<&'static str, String>::new();
         let mut texts = BTreeMap::<&'static str, Vec<String>>::new();
-        let grids = BTreeMap::<&'static str, Rc<dyn GridTrait>>::new();
+        let grids = Vec::new();
         #[allow(unused_mut)]
         let mut uuid = BTreeMap::<&'static str, uuid::Uuid>::new();
         let fourier_coefficients = BTreeMap::<&'static str, FourierCoefficients>::new();

--- a/src/op/parsed_parameters.rs
+++ b/src/op/parsed_parameters.rs
@@ -90,6 +90,12 @@ impl ParsedParameters {
         }
         Err(Error::MissingParam(key.to_string()))
     }
+    pub fn texts(&self, key: &str) -> Result<&Vec<String>, Error> {
+        if let Some(value) = self.texts.get(key) {
+            return Ok(value);
+        }
+        Err(Error::MissingParam(key.to_string()))
+    }
     pub fn uuid(&self, key: &str) -> Result<uuid::Uuid, Error> {
         if let Some(value) = self.uuid.get(key) {
             return Ok(*value);

--- a/src/op/parsed_parameters.rs
+++ b/src/op/parsed_parameters.rs
@@ -53,7 +53,7 @@ pub struct ParsedParameters {
     // Pointers to the grids required by the operator
     // They should be inserted in the order they appear in the definition
     // NOTE: We may want to consider use `Arc` instead of `Rc` here for concurrency reasons
-    pub grids: Vec<Rc<dyn GridTrait>>,
+    pub grids: Vec<Rc<dyn Grid>>,
 }
 
 // Accessors

--- a/src/op/parsed_parameters.rs
+++ b/src/op/parsed_parameters.rs
@@ -4,6 +4,7 @@
 use crate::math::angular;
 use crate::math::FourierCoefficients;
 use std::collections::BTreeSet;
+use std::rc::Rc;
 
 use super::*;
 
@@ -42,7 +43,7 @@ pub struct ParsedParameters {
     pub integer: BTreeMap<&'static str, i64>,
     pub real: BTreeMap<&'static str, f64>,
     pub series: BTreeMap<&'static str, Vec<f64>>,
-    pub grids: BTreeMap<&'static str, Grid>,
+    pub grids: BTreeMap<&'static str, Rc<dyn GridTrait>>,
     pub text: BTreeMap<&'static str, String>,
     pub texts: BTreeMap<&'static str, Vec<String>>,
     pub uuid: BTreeMap<&'static str, uuid::Uuid>,
@@ -115,6 +116,39 @@ impl ParsedParameters {
         // If none of them existed, i.e. no defaults were given, we return the general default
         Ellipsoid::default()
     }
+    /// Returns the grid(s) associated with the operator
+    /// (typically a single grid, but some operators may
+    /// use multiple grids) which are provided as a Vec<&dyn GridTrait>
+    /// in the order they appear in the `grids` parameter.
+    pub fn get_grids(&self) -> Result<Vec<&Rc<dyn GridTrait>>, Error> {
+        //
+        if let Some(names) = self.text.get("grids") {
+            let grids = names
+                .split(",")
+                .map(|n| {
+                    self.grids.get(n).ok_or(Error::General(
+                        "Grid Not found, did you forget to set it with set_grid?",
+                    ))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(grids)
+        } else {
+            return Err(Error::MissingParam("grids".to_string()));
+        }
+    }
+
+    /// Construct and set grids required by this parameter
+    /// Operators that require a grid should get and create them in Inner_Op::new()
+    /// and then set them here. Typically the Context will have a way of loading a raw grid
+    pub fn set_grids(&mut self, grid: Vec<Rc<dyn GridTrait>>) {
+        if let Some(names) = self.text.get("grids") {
+            let names = names.split(",").collect::<Vec<_>>();
+            for (i, name) in names.iter().enumerate() {
+                self.grids.insert(name, grid[i].clone());
+            }
+        }
+    }
     pub fn k(&self, index: usize) -> f64 {
         *(self.real.get(&format!("k_{index}")[..]).unwrap_or(&1.))
     }
@@ -146,7 +180,7 @@ impl ParsedParameters {
         let mut series = BTreeMap::<&'static str, Vec<f64>>::new();
         let mut text = BTreeMap::<&'static str, String>::new();
         let mut texts = BTreeMap::<&'static str, Vec<String>>::new();
-        let grids = BTreeMap::<&'static str, Grid>::new();
+        let grids = BTreeMap::<&'static str, Rc<dyn GridTrait>>::new();
         #[allow(unused_mut)]
         let mut uuid = BTreeMap::<&'static str, uuid::Uuid>::new();
         let fourier_coefficients = BTreeMap::<&'static str, FourierCoefficients>::new();

--- a/src/op/parsed_parameters.rs
+++ b/src/op/parsed_parameters.rs
@@ -4,7 +4,7 @@
 use crate::math::angular;
 use crate::math::FourierCoefficients;
 use std::collections::BTreeSet;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::*;
 
@@ -52,8 +52,7 @@ pub struct ParsedParameters {
 
     // Pointers to the grids required by the operator
     // They should be inserted in the order they appear in the definition
-    // NOTE: We may want to consider use `Arc` instead of `Rc` here for concurrency reasons
-    pub grids: Vec<Rc<dyn Grid>>,
+    pub grids: Vec<Arc<dyn Grid>>,
 }
 
 // Accessors

--- a/tests/maximal.rs
+++ b/tests/maximal.rs
@@ -120,9 +120,9 @@ impl Context for Maximal {
         Ok(std::fs::read(path)?)
     }
     /// Access grid resources by identifier
-    fn get_grid(&self, name: &str) -> Result<Rc<dyn GridTrait>, Error> {
+    fn get_grid(&self, name: &str) -> Result<Rc<dyn Grid>, Error> {
         let buf = self.get_blob(name)?;
-        let grid = Grid::gravsoft(&buf)?;
+        let grid = BaseGrid::gravsoft(&buf)?;
 
         Ok(Rc::new(grid))
     }

--- a/tests/maximal.rs
+++ b/tests/maximal.rs
@@ -120,10 +120,11 @@ impl Context for Maximal {
         Ok(std::fs::read(path)?)
     }
     /// Access grid resources by identifier
-    fn get_grid(&self, _name: &str) -> Result<Rc<dyn GridTrait>, Error> {
-        Err(Error::General(
-            "Grid access by identifier not supported by the Maximal context provider",
-        ))
+    fn get_grid(&self, name: &str) -> Result<Rc<dyn GridTrait>, Error> {
+        let buf = self.get_blob(name)?;
+        let grid = Grid::gravsoft(&buf)?;
+
+        Ok(Rc::new(grid))
     }
 }
 

--- a/tests/maximal.rs
+++ b/tests/maximal.rs
@@ -1,7 +1,7 @@
 use geodesy::authoring::*;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::rc::Rc;
+use std::sync::Arc;
 
 // ----- U S E R   P R O V I D E D   C O N T E X T ----------------------------------
 
@@ -120,11 +120,11 @@ impl Context for Maximal {
         Ok(std::fs::read(path)?)
     }
     /// Access grid resources by identifier
-    fn get_grid(&self, name: &str) -> Result<Rc<dyn Grid>, Error> {
+    fn get_grid(&self, name: &str) -> Result<Arc<dyn Grid>, Error> {
         let buf = self.get_blob(name)?;
         let grid = BaseGrid::gravsoft(&buf)?;
 
-        Ok(Rc::new(grid))
+        Ok(Arc::new(grid))
     }
 }
 

--- a/tests/maximal.rs
+++ b/tests/maximal.rs
@@ -1,6 +1,7 @@
 use geodesy::authoring::*;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 // ----- U S E R   P R O V I D E D   C O N T E X T ----------------------------------
 
@@ -118,9 +119,8 @@ impl Context for Maximal {
         let path: PathBuf = [".", "geodesy", ext, name].iter().collect();
         Ok(std::fs::read(path)?)
     }
-
     /// Access grid resources by identifier
-    fn get_grid(&self, _name: &str) -> Result<Grid, Error> {
+    fn get_grid(&self, _name: &str) -> Result<Rc<dyn GridTrait>, Error> {
         Err(Error::General(
             "Grid access by identifier not supported by the Maximal context provider",
         ))


### PR DESCRIPTION
Callout: My implementation may be somewhat naive not knowing all the thought that's already gone into RG. That said I've attempted to, as simply as possible, add multi grid support while allowing alternate grid types via a new `GridTrait`. 

`GridTrait` has the methods required to support the `gridshift` and `deformation` operators. Notably it includes a `bands` method to replace the public `bands` property in the `Grid` struct. 

I changed how operators access a grid to go through the `get_grid` method on the context. Operators would get a reference to a grid from the context and then store it on the `ParsedParameters` struct. I've used a `Vec` there instead of a HashMap to avoid borrowing conflicts. All this has the advantage of empowering the context with grid handling. The previous implementation required operators to access a resource on the context and then create a grid. This is fine for systems who have access to the disk, but in web applications it requires doubling the memory requirement for the grid. First as a resource loaded at instantiation and then as a grid when the operator is used. 

To be able to use the GridTrait I had to wrap it in `Rc<dyn GridTrait>` to satisfy `Clone` requirements. I feel this is a positive because grids are readonly. Note, we might want to consider using `Arc` instead to facilitate concurrency? 

Lastly, I updated usage of the grid to work with a `Vec`. This allows definitions to apply multiple grids ie `gridshift grids=gridA.gsb,gridB.datum,gridC.tiff`. The grids are then applied one after the other. 


I've updated `ntv2` support accordingly https://github.com/Rennzie/geodesy/pull/1
which makes implementation in `geodesy-wasm` simpler: https://github.com/Rennzie/geodesy-wasm/pull/28

Interested to hear your thoughts.