### PR TITLE
Better basegrid

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -33,12 +33,9 @@ pub struct BaseGrid {
     rows: usize,
     cols: usize,
     pub bands: usize,
-    offset: usize, // typically 0, but may be any number for externally stored grids
-    #[allow(dead_code)]
-    last_valid_record_start: usize,
+    offset: usize,  // typically 0, but may be any number for externally stored grids
     grid: Vec<f32>, // May be zero sized in cases where the Context provides access to an externally stored grid
 }
-
 
 impl Grid for BaseGrid {
     fn bands(&self) -> usize {
@@ -96,7 +93,8 @@ impl Grid for BaseGrid {
         let rlat = at[1] - self.lat_0;
 
         // The (row, column) of the lower left node of the grid cell containing
-        // coord or, in the case of extrapolation, the nearest cell inside the grid.
+        // the interpolation coordinate - or, in the case of extrapolation:
+        // the nearest cell inside the grid.
         let row = (rlat / self.dlat).floor() as i64;
         let col = (rlon / self.dlon).floor() as i64;
 
@@ -112,9 +110,12 @@ impl Grid for BaseGrid {
             self.offset + self.bands * (self.cols * (row - 1) + col    ),
         );
 
-        // Cell relative, cell unit coordinates in a right handed CS (hence .abs())
-        let rlon = (at[0] - (self.lon_0 + col as f64 * self.dlon)) / self.dlon.abs();
-        let rlat = (at[1] - (self.lat_0 + row as f64 * self.dlat)) / self.dlat.abs();
+        let ll_lon = self.lon_0 + col as f64 * self.dlon;
+        let ll_lat = self.lat_0 + row as f64 * self.dlat;
+
+        // Cell relative, cell unit coordinates in a right handed CS
+        let rlon = (at[0] - ll_lon) / self.dlon;
+        let rlat = (at[1] - ll_lat) / -self.dlat;
 
         // Interpolate
         let mut left = Coor4D::origin();
@@ -144,8 +145,8 @@ impl BaseGrid {
             return Err(Error::General("Incomplete grid"));
         }
 
-        let lat_0 = header[1];
-        let lat_1 = header[0];
+        let lat_0 = header[0];
+        let lat_1 = header[1];
         let lon_0 = header[2];
         let lon_1 = header[3];
         let dlat = header[4].copysign(lat_1 - lat_0);
@@ -156,7 +157,6 @@ impl BaseGrid {
         let elements = rows * cols * bands;
 
         let offset = offset.unwrap_or(0);
-        let last_valid_record_start = offset + (rows * cols - 1) * bands;
 
         let grid = Vec::from(grid.unwrap_or(&[]));
 
@@ -175,7 +175,6 @@ impl BaseGrid {
             cols,
             bands,
             offset,
-            last_valid_record_start,
             grid,
         })
     }
@@ -207,7 +206,7 @@ fn normalize_gravsoft_grid_values(header: &mut [f64], grid: &mut [f32]) {
         return;
     }
 
-    // For horizontal datum shifts, the grid values are in minutes-of-arc
+    // For horizontal datum shifts, the grid values are in seconds-of-arc
     // and in latitude/longitude order. Swap them and convert into radians.
     if h.bands == 2 {
         for i in 0..grid.len() {
@@ -258,13 +257,20 @@ fn gravsoft_grid_reader(buf: &[u8]) -> Result<(Vec<f64>, Vec<f32>), Error> {
         return Err(Error::General("Incomplete Gravsoft header"));
     }
 
+    // The Gravsoft header has lat_1 before lat_0
+    header.swap(0, 1);
+
     // Count the number of bands
-    let lat_0 = header[1];
-    let lat_1 = header[0];
+    let lat_0 = header[0];
+    let lat_1 = header[1];
     let lon_0 = header[2];
     let lon_1 = header[3];
-    let dlat = -header[4]; // minus because rows go from north to south
-    let dlon = header[5];
+
+    // The Gravsoft header has inverted sign for dlat. We force
+    // the two deltas to have signs compatible with the grid
+    // organization
+    let dlat = header[4].copysign(lat_1 - lat_0);
+    let dlon = header[5].copysign(lon_1 - lon_0);
     let rows = ((lat_1 - lat_0) / dlat + 1.5).floor() as usize;
     let cols = ((lon_1 - lon_0) / dlon + 1.5).floor() as usize;
     let bands = grid.len() / (rows * cols);
@@ -292,20 +298,13 @@ fn gravsoft_grid_reader(buf: &[u8]) -> Result<(Vec<f64>, Vec<f32>), Error> {
 }
 
 // ----- T E S T S ------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const HEADER: [f64; 6] = [54., 58., 8., 16., 1., 1.];
-
-    #[rustfmt::skip]
-    const GEOID: [f32; 5*9] = [
-        58.08, 58.09, 58.10, 58.11, 58.12, 58.13, 58.14, 58.15, 58.16,
-        57.08, 57.09, 57.10, 57.11, 57.12, 57.13, 57.14, 57.15, 57.16,
-        56.08, 56.09, 56.10, 56.11, 56.12, 56.13, 56.14, 56.15, 56.16,
-        55.08, 55.09, 55.10, 55.11, 55.12, 55.13, 55.14, 55.15, 55.16,
-        54.08, 54.09, 54.10, 54.11, 54.12, 54.13, 54.14, 54.15, 54.16,
-    ];
+    // lat_0, lat_1, lon_0, lon_1, dlat, dlon
+    const HEADER: [f64; 6] = [58., 54., 8., 16., -1., 1.];
 
     #[allow(dead_code)]
     #[rustfmt::skip]
@@ -317,29 +316,61 @@ mod tests {
         54., 08., 54., 09., 54., 10., 54., 11., 54., 12., 54., 13., 54., 14., 54., 15., 54., 16.,
     ];
 
+    #[rustfmt::skip]
+    const GEOID: [f32; 5*9] = [
+        58.08, 58.09, 58.10, 58.11, 58.12, 58.13, 58.14, 58.15, 58.16,
+        57.08, 57.09, 57.10, 57.11, 57.12, 57.13, 57.14, 57.15, 57.16,
+        56.08, 56.09, 56.10, 56.11, 56.12, 56.13, 56.14, 56.15, 56.16,
+        55.08, 55.09, 55.10, 55.11, 55.12, 55.13, 55.14, 55.15, 55.16,
+        54.08, 54.09, 54.10, 54.11, 54.12, 54.13, 54.14, 54.15, 54.16,
+    ];
+
+    // A geoid in inverse row order
+    #[rustfmt::skip]
+    const UPSIDE_DOWN_GEOID: [f32; 5*9] = [
+        54.08, 54.09, 54.10, 54.11, 54.12, 54.13, 54.14, 54.15, 54.16,
+        55.08, 55.09, 55.10, 55.11, 55.12, 55.13, 55.14, 55.15, 55.16,
+        56.08, 56.09, 56.10, 56.11, 56.12, 56.13, 56.14, 56.15, 56.16,
+        57.08, 57.09, 57.10, 57.11, 57.12, 57.13, 57.14, 57.15, 57.16,
+        58.08, 58.09, 58.10, 58.11, 58.12, 58.13, 58.14, 58.15, 58.16,
+    ];
+
+    #[rustfmt::skip]
+    const MIRRORED_GEOID: [f32; 5*9] = [
+        58.16, 58.15, 58.14, 58.13, 58.12, 58.11, 58.10, 58.09, 58.08,
+        57.16, 57.15, 57.14, 57.13, 57.12, 57.11, 57.10, 57.09, 57.08,
+        56.16, 56.15, 56.14, 56.13, 56.12, 56.11, 56.10, 56.09, 56.08,
+        55.16, 55.15, 55.14, 55.13, 55.12, 55.11, 55.10, 55.09, 55.08,
+        54.16, 54.15, 54.14, 54.13, 54.12, 54.11, 54.10, 54.09, 54.08,
+    ];
+
+    #[rustfmt::skip]
+    const MIRRORED_UPSIDE_DOWN_GEOID: [f32; 5*9] = [
+        54.16, 54.15, 54.14, 54.13, 54.12, 54.11, 54.10, 54.09, 54.08,
+        55.16, 55.15, 55.14, 55.13, 55.12, 55.11, 55.10, 55.09, 55.08,
+        56.16, 56.15, 56.14, 56.13, 56.12, 56.11, 56.10, 56.09, 56.08,
+        57.16, 57.15, 57.14, 57.13, 57.12, 57.11, 57.10, 57.09, 57.08,
+        58.16, 58.15, 58.14, 58.13, 58.12, 58.11, 58.10, 58.09, 58.08,
+    ];
     #[test]
     fn grid_header() -> Result<(), Error> {
         // Create a datum correction grid (2 bands)
         let mut datum_header = Vec::from(HEADER);
+
+        // Since we use normalize_gravsoft...(...) to handle angular normalization,
+        // we need a Gravsoft style header here
+        datum_header.swap(0, 1);
+        datum_header[4] = -datum_header[4];
         datum_header.push(2_f64); // 2 bands
         let mut datum_grid = Vec::from(DATUM);
         normalize_gravsoft_grid_values(&mut datum_header, &mut datum_grid);
+
+        // But Since we use BaseGrid::plain(...) to instantiate, we need a plain header here
+        datum_header.swap(0, 1);
+        datum_header[4] = -datum_header[4];
         let datum = BaseGrid::plain(&datum_header, Some(&datum_grid), None)?;
 
-        // Create a geoid grid (1 band)
-        let mut geoid_header = Vec::from(HEADER);
-        geoid_header.push(1_f64); // 1 band
-        let mut geoid_grid = Vec::from(GEOID);
-        normalize_gravsoft_grid_values(&mut geoid_header, &mut geoid_grid);
-        let geoid = BaseGrid::plain(&geoid_header, Some(&geoid_grid), None)?;
-
-        let c = Coor4D::geo(58.75, 08.25, 0., 0.);
-        assert_eq!(geoid.contains(&c, 0.0), false);
-        assert_eq!(geoid.contains(&c, 1.0), true);
-
-        let n = geoid.at(&c, 1.0).unwrap();
-        assert!((n[0] - 58.83).abs() < 0.1);
-
+        let c = Coor4D::geo(55.06, 12.03, 0., 0.);
         let d = datum.at(&c, 1.0).unwrap();
         assert!(c.default_ellps_dist(&d.to_arcsec().to_radians()) < 1.0);
 
@@ -366,6 +397,82 @@ mod tests {
         // but the grid values are f32, so we have only approx 7 significant
         // figures...
         assert!(c.to_degrees().hypot2(&d) < 1e-5);
+
+        // Create a geoid grid (1 band)
+        let mut geoid_header = datum_header.clone();
+        geoid_header[6] = 1.0; // 1 band
+        let geoid_grid = Vec::from(GEOID);
+        let geoid = BaseGrid::plain(&geoid_header, Some(&geoid_grid), None)?;
+
+        let c = Coor4D::geo(58.75, 08.25, 0., 0.);
+        assert_eq!(geoid.contains(&c, 0.0), false);
+        assert_eq!(geoid.contains(&c, 1.0), true);
+
+        let n = geoid.at(&c, 1.0).unwrap();
+        assert!((n[0] - (58.75 + 0.0825)).abs() < 0.0001);
+
+        // Create an upside-down geoid grid (1 band)
+        let mut geoid_header = datum_header.clone();
+        geoid_header.swap(0, 1); // lat_0=54, lat_1=58
+        geoid_header[6] = 1.0; // 1 band
+        let geoid_grid = Vec::from(UPSIDE_DOWN_GEOID);
+        let geoid = BaseGrid::plain(&geoid_header, Some(&geoid_grid), None)?;
+
+        let c = Coor4D::geo(58.75, 08.25, 0., 0.);
+        assert_eq!(geoid.contains(&c, 0.0), false);
+        assert_eq!(geoid.contains(&c, 1.0), true);
+
+        let n = geoid.at(&c, 1.0).unwrap();
+        assert!((n[0] - 58.83).abs() < 0.1);
+
+        let c = Coor4D::geo(53.25, 8.0, 0., 0.);
+        assert_eq!(geoid.contains(&c, 0.0), false);
+        assert_eq!(geoid.contains(&c, 1.0), true);
+
+        let n = geoid.at(&c, 1.0).unwrap();
+        assert!((n[0] - (53.25 + 0.08)).abs() < 0.0001);
+
+        // Create a mirrored geoid grid (1 band)
+        let mut geoid_header = datum_header.clone();
+        geoid_header.swap(2, 3); // lon_0=16, lon_1=8
+        geoid_header[5] = -geoid_header[5];
+        geoid_header[6] = 1.0; // 1 band
+        let geoid_grid = Vec::from(MIRRORED_GEOID);
+        let geoid = BaseGrid::plain(&geoid_header, Some(&geoid_grid), None)?;
+
+        let c = Coor4D::geo(58.75, 08.25, 0., 0.);
+        assert_eq!(geoid.contains(&c, 0.0), false);
+        assert_eq!(geoid.contains(&c, 1.0), true);
+
+        let n = geoid.at(&c, 1.0).unwrap();
+        assert!((n[0] - 58.83).abs() < 0.1);
+
+        let c = Coor4D::geo(53.25, 8.0, 0., 0.);
+        assert_eq!(geoid.contains(&c, 0.0), false);
+        assert_eq!(geoid.contains(&c, 1.0), true);
+
+        let n = geoid.at(&c, 1.0).unwrap();
+        assert!((n[0] - (53.25 + 0.08)).abs() < 0.001);
+
+        // Create a mirrored upside down geoid grid (1 band)
+        geoid_header.swap(0, 1); // lon_0=16, lon_1=8
+        geoid_header[4] = -geoid_header[4];
+        let geoid_grid = Vec::from(MIRRORED_UPSIDE_DOWN_GEOID);
+        let geoid = BaseGrid::plain(&geoid_header, Some(&geoid_grid), None)?;
+
+        let c = Coor4D::geo(58.75, 08.25, 0., 0.);
+        assert_eq!(geoid.contains(&c, 0.0), false);
+        assert_eq!(geoid.contains(&c, 1.0), true);
+
+        let n = geoid.at(&c, 1.0).unwrap();
+        assert!((n[0] - 58.83).abs() < 0.1);
+
+        let c = Coor4D::geo(53.25, 8.0, 0., 0.);
+        assert_eq!(geoid.contains(&c, 0.0), false);
+        assert_eq!(geoid.contains(&c, 1.0), true);
+
+        let n = geoid.at(&c, 1.0).unwrap();
+        assert!((n[0] - (53.25 + 0.08)).abs() < 0.001);
 
         Ok(())
     }

--- a/src/inner_op/deformation.rs
+++ b/src/inner_op/deformation.rs
@@ -132,10 +132,10 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     'points: for i in 0..n {
         let cart = operands.get_coord(i);
         let geo = ellps.geographic(&cart);
-        for within in [0.0, 0.5] {
+        for margin in [0.0, 0.5] {
             for grid in grids.iter() {
                 // Interpolated deformation velocity
-                if let Some(v) = grid.interpolation(&geo, within) {
+                if let Some(v) = grid.at(&geo, margin) {
                     // The deformation duration may be given either as a fixed duration or
                     // as the difference between the frame epoch and the observation epoch
                     let d = if dt.is_finite() { dt } else { epoch - geo[3] };
@@ -188,10 +188,10 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     'points: for i in 0..n {
         let cart = operands.get_coord(i);
         let geo = ellps.geographic(&cart);
-        for within in [0.0, 0.5] {
+        for margin in [0.0, 0.5] {
             for grid in grids.iter().rev() {
                 // Interpolated deformation velocity
-                if let Some(v) = grid.interpolation(&geo, within) {
+                if let Some(v) = grid.at(&geo, margin) {
                     // The deformation duration may be given either as a fixed duration or
                     // as the difference between the frame epoch and the observation epoch
                     let d = if dt.is_finite() { dt } else { epoch - geo[3] };
@@ -344,7 +344,7 @@ mod tests {
         let grid = BaseGrid::gravsoft(&buf)?;
 
         // Velocity in the ENU space
-        let v = grid.interpolation(&cph, 0.0).unwrap();
+        let v = grid.at(&cph, 0.0).unwrap();
         // Which we rotate into the XYZ space and integrate for 1000 years
         let deformation = rotate_and_integrate_velocity(v, cph[0], cph[1], 1000.);
 

--- a/src/inner_op/gridshift.rs
+++ b/src/inner_op/gridshift.rs
@@ -13,9 +13,9 @@ fn fwd(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     'points: for i in 0..n {
         let mut coord = operands.get_coord(i);
 
-        for within in [0.0, 0.5] {
+        for margin in [0.0, 0.5] {
             for grid in grids.iter() {
-                if let Some(d) = grid.interpolation(&coord, within) {
+                if let Some(d) = grid.at(&coord, margin) {
                     // Geoid
                     if grid.bands() == 1 {
                         coord[2] -= d[0];
@@ -60,9 +60,9 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
     'points: for i in 0..n {
         let mut coord = operands.get_coord(i);
 
-        for within in [0.0, 0.5] {
+        for margin in [0.0, 0.5] {
             for grid in grids.iter().rev() {
-                if let Some(t) = grid.interpolation(&coord, within) {
+                if let Some(t) = grid.at(&coord, margin) {
                     // Geoid
                     if grid.bands() == 1 {
                         coord[2] += t[0];
@@ -76,7 +76,7 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
                     let mut t = coord - t;
 
                     'iterate: for _ in 0..10 {
-                        if let Some(t2) = grid.interpolation(&t, within) {
+                        if let Some(t2) = grid.at(&t, margin) {
                             let d = t - coord + t2;
                             t = t - d;
                             // i.e. d.dot(d).sqrt() < 1e-10


### PR DESCRIPTION
Changed method names for BaseGrid:

- `interpolation(...)` is now `at(...)`, i.e. `grid.at(...)`, to avoid any confusion about whether extrapolation is supported
- The `within` arg to `contains(...)` has been changed to `margin`

Changed the plain header to expect `(lat_0, lon_0)` to be the coordinate tuple of the first node of the grid, and `(lat_1, lon_1)` to be the coordinate tuple of the first node of the grid. In ALL cases. The builtin Gravsoft reader swaps signs and orders to fit with this.

Generalized `BaseGrid` to handle any grid orientation (left-right, right-left, upside-down, downside-up, and any combination thereof), everything determined from the values of `lat_0, lat_1, lon_0, lon_1`, which are also used to assign the correct sign to `dlat, dlon`.
