### PR TITLE
A number of improvements to the grid handling

### DIFF
--- a/src/inner_op/deformation.rs
+++ b/src/inner_op/deformation.rs
@@ -189,7 +189,7 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
         let cart = operands.get_coord(i);
         let geo = ellps.geographic(&cart);
         for margin in [0.0, 0.5] {
-            for grid in grids.iter().rev() {
+            for grid in grids.iter() {
                 // Interpolated deformation velocity
                 if let Some(v) = grid.at(&geo, margin) {
                     // The deformation duration may be given either as a fixed duration or

--- a/src/inner_op/gridshift.rs
+++ b/src/inner_op/gridshift.rs
@@ -61,7 +61,7 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
         let mut coord = operands.get_coord(i);
 
         for margin in [0.0, 0.5] {
-            for grid in grids.iter().rev() {
+            for grid in grids.iter() {
                 if let Some(t) = grid.at(&coord, margin) {
                     // Geoid
                     if grid.bands() == 1 {


### PR DESCRIPTION
Two interpolation tests in ntv2/mod.rs (succesfully validated against ESRI's ntv2_cvt program)

Improve check for NTv2 file header sanity

Improve readability and correct vector capacity in ntv2 parse_subgrid_grid()

Reduce visibility of SubGridHeader

Clean up the `use` block in ntv2 subgrid.rs

In the inverse case, don't iterate in reverse order over the grid collection in deformation & gridshift operators (we still want to hit the same grid as in the forward case)