### PR TITLE
remove feature gates

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -1,6 +1,5 @@
 //! Grid characteristics and interpolation.
 
-// #[cfg(feature = "ntv2")]
 pub mod ntv2;
 use crate::prelude::*;
 use std::{fmt::Debug, io::BufRead};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,6 @@ pub use crate::op::OpParameter;
 pub use crate::op::ParsedParameters;
 pub use crate::op::RawParameters;
 
-#[cfg(feature = "ntv2")]
 pub use crate::grid::ntv2::Ntv2Grid;
 
 #[cfg(doc)]


### PR DESCRIPTION
We missed one feature gate which was preventing me from importing the `Ntv2Grid` into geodesy-wasm.