### PR TITLE
Add NTv2 multi subgrid support

### DIFF
--- a/src/grid/ntv2/mod.rs
+++ b/src/grid/ntv2/mod.rs
@@ -66,35 +66,60 @@ impl Ntv2Grid {
     }
 
     // As defined by the FGRID subroutine in the NTv2 [spec](https://web.archive.org/web/20140127204822if_/http://www.mgs.gov.on.ca:80/stdprodconsume/groups/content/@mgs/@iandit/documents/resourcelist/stel02_047447.pdf) (page 42)
-    fn find_grid(&self, coord: &Coor4D, margin: f64) -> Option<&BaseGrid> {
-        // Start with grids whose parent grid id is `NONE`
-        let mut current_parent_id: String = "NONE".to_string();
-        let mut queue = self.lookup_table.get(&current_parent_id).unwrap().clone();
+    fn find_grid(&self, coord: &Coor4D, margin: f64) -> Option<(String, &BaseGrid)> {
+        // Start with the base grids whose parent id is `NONE`
+        let mut current_grid_id: String = "NONE".to_string();
+        let mut queue = self.lookup_table.get(&current_grid_id).unwrap().clone();
 
-        while let Some(child_id) = queue.pop() {
-            // Unwrappping is safe as a panic means we didn't
+        while let Some(grid_id) = queue.pop() {
+            // Unwrapping is safe because a panic means we didn't
             // properly populate the `lookup_table` & `subgrids` properties
-            let current_grid = self.subgrids.get(&child_id).unwrap();
+            let current_grid = self.subgrids.get(&grid_id).unwrap();
 
-            // The NTv2 spec has a myriad of different options for handling coordinates
-            // that fall on the boundaries of a grid. We've chosen to ignore them for now
-            // and return most dense AND first grid that contains the coordinate.
-            // This should be relatively safe given then NTv2 spec does ensure that grids cannot overlap.
-            // See the FGRID subroutine in the NTv2 spec linked above for more details.
-            // NOTE: We may want to consider enforcing a margin of 0.0 for inner grids.
-            if current_grid.contains(coord, margin) {
-                current_parent_id = child_id.clone();
-
-                if let Some(children) = self.lookup_table.get(&current_parent_id) {
-                    queue = children.clone();
+            // We do a strict margin check on the first pass because grids cannot overlap in the NTv2 spec
+            if current_grid.contains(coord, 1e-6) {
+                // BaseGrid considers on the line to be in but by NTv2 standards points on
+                // either upper latitude or longitude are considered outside the grid.
+                // We explicitly check for this case here and keep trying if it happens.
+                let (lat_n, lon_e) = (current_grid.lat_n, current_grid.lon_e);
+                if (coord[0] - lon_e).abs() < 1e-6 || (coord[1] - lat_n).abs() < 1e-6 {
                     continue;
                 }
-                // If we get here it means the current_parent_id has no children and we have found the grid
-                break;
+
+                current_grid_id = grid_id.clone();
+
+                if let Some(children) = self.lookup_table.get(&current_grid_id) {
+                    queue = children.clone();
+                } else {
+                    // If we get here it means the current_parent_id has no children and we've found the grid
+                    break;
+                }
             }
         }
 
-        self.subgrids.get(&current_parent_id)
+        if let Some(grid) = self.subgrids.get(&current_grid_id) {
+            return Some((current_grid_id, grid));
+        }
+
+        // There's a chance the point fell on the upper boundary of one of the base grids,
+        // or it's within the specified margin. If this happens we re-evaluate the
+        // base grids, this time using the specified margin.
+        // At this point we've evaluated all the internal boundaries between grids and found no
+        // match. That means the only possible option is that one of the base grids contains the point
+        // within it's outer margin.
+        if current_grid_id == "NONE" {
+            // Find the first base grid which contain the point +- the margin, if at all.
+            for base_grid_id in self.lookup_table.get(&current_grid_id).unwrap() {
+                if let Some(base_grid) = self.subgrids.get(base_grid_id) {
+                    if base_grid.contains(coord, margin) {
+                        return Some((base_grid_id.clone(), base_grid));
+                    }
+                }
+            }
+        }
+
+        // None of the subgrids contain the point
+        None
     }
 }
 
@@ -105,20 +130,12 @@ impl Grid for Ntv2Grid {
 
     /// Checks if a `Coord4D` is within the grid limits +- `margin` grid units
     fn contains(&self, position: &Coor4D, margin: f64) -> bool {
-        if self.find_grid(position, margin).is_some() {
-            return true;
-        }
-
-        false
+        self.find_grid(position, margin).is_some()
     }
 
     fn at(&self, coord: &Coor4D, margin: f64) -> Option<Coor4D> {
-        if let Some(grid) = self.find_grid(coord, margin) {
-            return grid.at(coord, margin);
-        }
-
-        // If we get here the grid does not contain the coordinate
-        None
+        self.find_grid(coord, margin)
+            .and_then(|grid| grid.1.at(coord, margin))
     }
 }
 
@@ -173,6 +190,98 @@ mod tests {
         dbg!((dlon, dlat));
         assert_float_eq!(dlat, -4.1843700409, abs_all <= 1e-6);
         assert_float_eq!(dlon, -3.9602699280, abs_all <= 1e-6);
+        Ok(())
+    }
+
+    #[test]
+    fn ntv2_multi_subgrid() -> Result<(), Error> {
+        let grid_buff = std::fs::read("geodesy/gsb/5458_with_subgrid.gsb").unwrap();
+        let ntv2_grid = Ntv2Grid::new(&grid_buff)?;
+
+        assert!(ntv2_grid.subgrids.len() == 2);
+        assert!(ntv2_grid.lookup_table.get("NONE").unwrap().len() > 0);
+        assert!(ntv2_grid
+            .lookup_table
+            .get("NONE")
+            .unwrap()
+            .contains(&"5458".to_string()));
+
+        // Grids with no children do not appear in the lookup table
+        assert!(ntv2_grid.lookup_table.get("5556").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn ntv2_multi_subgrid_find_grid() -> Result<(), Error> {
+        let grid_buff = std::fs::read("geodesy/gsb/5458_with_subgrid.gsb").unwrap();
+        let ntv2_grid = Ntv2Grid::new(&grid_buff)?;
+
+        // A point within the densified subgrid is contained by it
+        let within_densified_grid = Coor4D::geo(55.5, 13.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&within_densified_grid, 1e-6).unwrap();
+        assert_eq!(grid_id, "5556");
+
+        // A point on the upper latitude of the densified subgrid falls outside that grid
+        let on_densified_upper_lat = Coor4D::geo(56.0, 13.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_densified_upper_lat, 1e-6).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point on the upper longitude of the densified subgrid falls outside that grid
+        let on_densified_upper_lon = Coor4D::geo(55.5, 14.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_densified_upper_lon, 1e-6).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point on the lower latitude of the densified subgrid is contained by it
+        let on_densified_lower_lat = Coor4D::geo(55.0, 13.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_densified_lower_lat, 1e-6).unwrap();
+        assert_eq!(grid_id, "5556");
+
+        // A point on the lower longitude of the densified subgrid is contained by it
+        let on_densified_lower_lon = Coor4D::geo(55.5, 12.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_densified_lower_lon, 1e-6).unwrap();
+        assert_eq!(grid_id, "5556");
+
+        // A point on the upper latitude of the base grid is contained by it
+        let on_root_upper_lat = Coor4D::geo(58.0, 12.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_root_upper_lat, 1e-6).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point on the upper longitude of the base grid is contained by it
+        let on_root_upper_lon = Coor4D::geo(55.5, 16.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_root_upper_lon, 1e-6).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point on the lower latitude of the base grid is contained by it
+        let on_root_lower_lat = Coor4D::geo(54.0, 12.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_root_lower_lat, 1e-6).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point on the lower longitude of the base grid is contained by it
+        let on_root_lower_lon = Coor4D::geo(55.5, 8.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_root_lower_lon, 1e-6).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point within the margin of the upper latitude of the base grid is contained by it
+        let on_root_upper_lat = Coor4D::geo(58.25, 12.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_root_upper_lat, 0.5).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point within the margin of the upper longitude of the base grid is contained by it
+        let on_root_upper_lon = Coor4D::geo(55.5, 16.25, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_root_upper_lon, 0.5).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point within the margin of the lower latitude of the base grid is contained by it
+        let on_root_lower_lat = Coor4D::geo(53.75, 12.0, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_root_lower_lat, 0.5).unwrap();
+        assert_eq!(grid_id, "5458");
+
+        // A point within the margin of the lower longitude of the base grid is contained by it
+        let on_root_lower_lon = Coor4D::geo(55.5, 7.75, 0.0, 0.0);
+        let (grid_id, _) = ntv2_grid.find_grid(&on_root_lower_lon, 0.5).unwrap();
+        assert_eq!(grid_id, "5458");
+
         Ok(())
     }
 }

--- a/src/grid/ntv2/subgrid.rs
+++ b/src/grid/ntv2/subgrid.rs
@@ -22,8 +22,8 @@ pub(super) fn ntv2_subgrid(
 }
 
 // Buffer offsets for the NTv2 subgrid header
-pub(super) const NAME: usize = 8;
-pub(super) const PARENT: usize = 24;
+const NAME: usize = 8;
+const PARENT: usize = 24;
 const NLAT: usize = 88;
 const SLAT: usize = 72;
 const ELON: usize = 104;

--- a/src/grid/ntv2/subgrid.rs
+++ b/src/grid/ntv2/subgrid.rs
@@ -10,15 +10,9 @@ pub(super) fn ntv2_subgrid(
 
     let grid_start = head_offset + HEADER_SIZE;
     let grid = parse_subgrid_grid(parser, grid_start, head.num_nodes as usize)?;
-    let header = [
-        //head.slat, head.nlat, head.elon, head.wlon, head.dlat, head.dlon, 2.0,
-        head.nlat, head.slat, head.wlon, head.elon, head.dlat, head.dlon, 2.0,
-    ];
-    Ok(SubGrid {
-        name: head.name,
-        parent: head.parent,
-        grid: BaseGrid::plain(&header, Some(&grid), Some(0))?,
-    })
+    let header = head.into_header();
+    let base_grid = BaseGrid::plain(&header, Some(&grid), Some(0))?;
+    Ok((name, parent, base_grid))
 }
 
 // Buffer offsets for the NTv2 subgrid header
@@ -82,7 +76,7 @@ impl SubGridHeader {
 
     fn into_header(self) -> [f64; 7] {
         [
-            self.slat, self.nlat, self.elon, self.wlon, self.dlat, self.dlon, 2.0,
+            self.nlat, self.slat, self.wlon, self.elon, self.dlat, self.dlon, 2.0,
         ]
     }
 }


### PR DESCRIPTION
Adds support for multiple NTv2 subgrids. The implementation is adapted from the FGRID subroutine described in the [archived spec (pg 42)](https://web.archive.org/web/20140127204822if_/http://www.mgs.gov.on.ca:80/stdprodconsume/groups/content/@mgs/@iandit/documents/resourcelist/stel02_047447.pdf). 

I've done my best to be fully compliant to the FGRID rules of NTv2. There may be some edge cases missing though.