### PR TITLE
Considering alternative parameter names for the Helmert operator

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -2,12 +2,9 @@ use std::sync::Arc;
 
 use crate::authoring::*;
 pub mod minimal;
-pub use minimal::Minimal;
 
 #[cfg(feature = "with_plain")]
 pub mod plain;
-#[cfg(feature = "with_plain")]
-pub use plain::Plain;
 
 // ----- T H E   C O N T E X T   T R A I T ---------------------------------------------
 

--- a/src/inner_op/helmert.rs
+++ b/src/inner_op/helmert.rs
@@ -180,9 +180,24 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
     // Translation
     let translation = params.texts("translation")?.clone();
     if translation.len() == 3 {
-        params.real.insert("x", translation[0].parse::<f64>().expect("Failed parsing translation"));
-        params.real.insert("y", translation[1].parse::<f64>().expect("Failed parsing translation"));
-        params.real.insert("z", translation[2].parse::<f64>().expect("Failed parsing translation"));
+        params.real.insert(
+            "x",
+            translation[0]
+                .parse::<f64>()
+                .expect("Failed parsing translation"),
+        );
+        params.real.insert(
+            "y",
+            translation[1]
+                .parse::<f64>()
+                .expect("Failed parsing translation"),
+        );
+        params.real.insert(
+            "z",
+            translation[2]
+                .parse::<f64>()
+                .expect("Failed parsing translation"),
+        );
     }
     let x = params.real("x")?;
     let y = params.real("y")?;
@@ -190,11 +205,20 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
     let mut T = [x, y, z];
 
     // Time evolution of translation
-    let velocity: Vec<String>= params.texts("velocity")?.clone();
+    let velocity: Vec<String> = params.texts("velocity")?.clone();
     if velocity.len() == 3 {
-        params.real.insert("dx", velocity[0].parse::<f64>().expect("Failed parsing velocity"));
-        params.real.insert("dy", velocity[1].parse::<f64>().expect("Failed parsing velocity"));
-        params.real.insert("dz", velocity[2].parse::<f64>().expect("Failed parsing velocity"));
+        params.real.insert(
+            "dx",
+            velocity[0].parse::<f64>().expect("Failed parsing velocity"),
+        );
+        params.real.insert(
+            "dy",
+            velocity[1].parse::<f64>().expect("Failed parsing velocity"),
+        );
+        params.real.insert(
+            "dz",
+            velocity[2].parse::<f64>().expect("Failed parsing velocity"),
+        );
     }
     let dx = params.real("dx")?;
     let dy = params.real("dy")?;
@@ -204,9 +228,18 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
     // Rotation
     let rotation: Vec<String> = params.texts("rotation")?.clone();
     if rotation.len() == 3 {
-        params.real.insert("rx", rotation[0].parse::<f64>().expect("Failed parsing rotation"));
-        params.real.insert("ry", rotation[1].parse::<f64>().expect("Failed parsing rotation"));
-        params.real.insert("rz", rotation[2].parse::<f64>().expect("Failed parsing rotation"));
+        params.real.insert(
+            "rx",
+            rotation[0].parse::<f64>().expect("Failed parsing rotation"),
+        );
+        params.real.insert(
+            "ry",
+            rotation[1].parse::<f64>().expect("Failed parsing rotation"),
+        );
+        params.real.insert(
+            "rz",
+            rotation[2].parse::<f64>().expect("Failed parsing rotation"),
+        );
     }
     let rx = params.real("rx")?;
     let ry = params.real("ry")?;
@@ -220,9 +253,24 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
     // Time evolution of rotation
     let angular_velocity: Vec<String> = params.texts("angular_velocity")?.clone();
     if angular_velocity.len() == 3 {
-        params.real.insert("drx", angular_velocity[0].parse::<f64>().expect("Failed parsing angular_velocity"));
-        params.real.insert("dry", angular_velocity[1].parse::<f64>().expect("Failed parsing angular_velocity"));
-        params.real.insert("drz", angular_velocity[2].parse::<f64>().expect("Failed parsing angular_velocity"));
+        params.real.insert(
+            "drx",
+            angular_velocity[0]
+                .parse::<f64>()
+                .expect("Failed parsing angular_velocity"),
+        );
+        params.real.insert(
+            "dry",
+            angular_velocity[1]
+                .parse::<f64>()
+                .expect("Failed parsing angular_velocity"),
+        );
+        params.real.insert(
+            "drz",
+            angular_velocity[2]
+                .parse::<f64>()
+                .expect("Failed parsing angular_velocity"),
+        );
     }
     let drx = params.real("drx")?;
     let dry = params.real("dry")?;
@@ -251,7 +299,7 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
     }
 
     // Scale and its time evolution
-    let mut S = 1.0 + (params.real("s")? + params.real("scale")?)* 1e-6;
+    let mut S = 1.0 + (params.real("s")? + params.real("scale")?) * 1e-6;
 
     let DS = (params.real("ds")? + params.real("scale_trend")?) * 1e-6;
 
@@ -467,7 +515,6 @@ mod tests {
         Ok(())
     }
 
-
     //& MY TESTS
 
     #[test]
@@ -534,5 +581,4 @@ mod tests {
 
         Ok(())
     }
-
 }

--- a/src/inner_op/helmert.rs
+++ b/src/inner_op/helmert.rs
@@ -451,7 +451,7 @@ mod tests {
     fn fixed_dynamic() -> Result<(), Error> {
         let mut ctx = Minimal::default();
         let definition = "
-            helmert  exact  convention = coordinate_frame
+            helmert  exact    convention = coordinate_frame
             drx = 0.00150379  dry = 0.00118346  drz = 0.00120716
             t_epoch = 2020.0  t_obs = 2018
         ";
@@ -519,7 +519,7 @@ mod tests {
         let definition = "
             helmert  exact    convention = coordinate_frame
             angular_velocity = 0.00150379, 0.00118346,  0.00120716
-            t_epoch = 2020.0
+            t_epoch = 2020.0 
         ";
         let op = ctx.op(definition)?;
 

--- a/src/inner_op/helmert.rs
+++ b/src/inner_op/helmert.rs
@@ -179,7 +179,6 @@ pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> 
 
     // Translation
     let translation = params.series("translation")?;
-    println!("translation: {:?}", translation);
     if translation.len() != 3 {
         return Err(Error::BadParam(
             "translation".to_string(),


### PR DESCRIPTION
Considering alternative parameter names for the Helmert transformation -- this optionally allows for translation, rotation and trends to be provided as triplets rather than requiring each direction be denoted.  #45 