### PR TITLE
Improved syntax and parameter handling

### DIFF
--- a/examples/08-user_defined_operators_using_proj.rs
+++ b/examples/08-user_defined_operators_using_proj.rs
@@ -140,7 +140,7 @@ pub fn proj_constructor(parameters: &RawParameters, _ctx: &dyn Context) -> Resul
     let mut proj_args = String::new();
     for (k, v) in given_args {
         // Remove "proj" or "proj inv" prefixes
-        if k == "inv" || k == "name" {
+        if k == "inv" || k == "_name" {
             continue;
         }
         proj_args += " +";

--- a/ruminations/000-rumination.md
+++ b/ruminations/000-rumination.md
@@ -210,6 +210,18 @@ Also, since pipelines are obviously akin to Unix style shell pipes, we use the U
 cart ellps=intl | helmert x=-87 y=-96 z=-120 | cart inv ellps=GRS80
 ```
 
+RG also supports the PROJ step modifiers `omit_fwd` and `omit_inv`, indicating that a given step should be omitted if the pipeline is executed in the forward (respectively inverse) direction. And while they may be used exactly as in the PROJ case, RG also provices a bit of syntactic sugar by introducing the alternative step delimiters '>' (for `omit_inv` steps) and '<' (for `omit_fwd` steps).
+
+This is especially useful for very long pipelines, utilizing a block-formatted syntax, where the start of each line clearly indicates in which direction(s) each step is taken:
+
+```geodesy
+> inv utm zone=33 ellps=intl   # only fwd
+| cart ellps=intl
+| helmert x=-87 y=-96 z=-120
+| cart inv ellps=GRS80
+< inv utm zone=32 ellps=GRS80  # only inv
+```
+
 ### Redefining the world
 
 Being intended for authoring of geodetic functionality, customization is a very important aspect of the RG design. Hence, RG allows temporal overshadowing of built in functionality by registering user defined macros and operators. This is treated in detail in examples [02 (macros)](/examples/02-user_defined_macros.rs) and [03 (operators)](/examples/03-user_defined_operators.rs). Here, let's just take a minimal look at the workflow, which can be described briefly as *define, register, instantiate, and use:*
@@ -333,7 +345,7 @@ From the detailed walkthrough of the example above, we can summarize "the philos
 
 ... and, although only sparsely touched upon above:
 
-- **Operator pipelines are awesome:** Perhaps not a surprising stance, since I invented the concept and implemented it in PROJ five years ago, through the [Plumbing for Pipelines](https://github.com/OSGeo/PROJ/pull/453) pull request.
+- **Operator pipelines are awesome:** Perhaps not a surprising stance, since I invented the concept and implemented it in PROJ in 2016, through the [Plumbing for Pipelines](https://github.com/OSGeo/PROJ/pull/453) pull request.
 
 While operator pipelines superficically look like the ISO-19100 series concept of *concatenated operations*, they are more general and as we pointed out in `[Knudsen et al, 2019]`, also very powerful as a system of bricks and mortar for the construction of new conceptual buildings. Use more pipelines!
 
@@ -351,7 +363,7 @@ Thomas Knudsen, Kristian Evers, Geir Arne Hjelle, Guðmundur Valsson, Martin Lid
 
 #### **Note:** ellps implied
 
-In both cases, the use of the GRS80 ellipsoid is implied, but may be expressly stated as  `utm zone=32 ellps=GRS80}` resp. `proj=utm zone=32 ellps=GRS80`
+In both cases, the use of the GRS80 ellipsoid is implied, but may be expressly stated as  `utm zone=32 ellps=GRS80` resp. `proj=utm zone=32 ellps=GRS80`
 
 In C, using PROJ, the demo program would resemble this (untested) snippet:
 

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -105,7 +105,7 @@ impl Op {
             ));
         }
 
-        let name = parameters.definition.operator_name("");
+        let name = parameters.definition.operator_name();
 
         // A pipeline?
         if parameters.definition.is_pipeline() {

--- a/src/op/parsed_parameters.rs
+++ b/src/op/parsed_parameters.rs
@@ -362,7 +362,7 @@ impl ParsedParameters {
         }
 
         let name = locals
-            .get("name")
+            .get("_name")
             .unwrap_or(&"unknown".to_string())
             .to_string();
 

--- a/src/op/raw_parameters.rs
+++ b/src/op/raw_parameters.rs
@@ -57,7 +57,7 @@ impl RawParameters {
         let mut recursion_level = self.recursion_level + 1;
         let mut globals = self.globals.clone();
         if definition.is_resource_name() {
-            globals.remove("name");
+            globals.remove("_name");
             globals.extend(definition.split_into_parameters());
             globals.remove("inv");
             recursion_level += 1;

--- a/tests/maximal.rs
+++ b/tests/maximal.rs
@@ -148,13 +148,13 @@ mod tests {
             "foo |  bar baz  =  bonk, bonk , bonk".split_into_steps().0[0],
             "foo"
         );
-        assert_eq!("foo bar baz=bonk".split_into_parameters()["name"], "foo");
+        assert_eq!("foo bar baz=bonk".split_into_parameters()["_name"], "foo");
         assert_eq!("foo bar baz=bonk".split_into_parameters()["bar"], "true");
         assert_eq!("foo bar baz=bonk".split_into_parameters()["baz"], "bonk");
         assert!("foo | bar".is_pipeline());
         assert!("foo:bar".is_resource_name());
-        assert_eq!("foo bar baz=bonk".operator_name(""), "foo");
-        assert_eq!("foo bar baz=  $bonk".operator_name(""), "foo");
+        assert_eq!("foo bar baz=bonk".operator_name(), "foo");
+        assert_eq!("foo bar baz=  $bonk".operator_name(), "foo");
         Ok(())
     }
 


### PR DESCRIPTION
Introduce syntactic sugar for omit_fwd and omit_inv through the alternative pipeline step delimiters '>' and '<':

- '>' (i.e. forward arrow)  is now sugar for '| omit_inv'
- '<' (i.e. backward arrow) is now sugar for '| omit_fwd'

Support utf-8 numerical subscripts as a synonym for _0..._9 in parameter names, e.g. 'x₀' is transformed into 'x_0'

Further clean up the token handling by removing the default argument for 'operator_name()', and changing the "hidden parameter name", used for accessing the operator name, from "name" to "_name", in better accordance with conventions commonly used for reserved names