### PR TITLE
Change log level in LAEA transform to debug

### DIFF
--- a/src/inner_op/laea.rs
+++ b/src/inner_op/laea.rs
@@ -162,7 +162,7 @@ fn inv(op: &Op, _ctx: &dyn Context, operands: &mut dyn CoordinateSet) -> usize {
         // Another case of PROJ reality hardening
         let asin_argument = 0.5 * rho / rq;
         if asin_argument.abs() > 1.0 {
-            warn!("LAEA: ({x}, {y}) outside domain");
+            debug!("LAEA: ({x}, {y}) outside domain");
             coord[0] = f64::NAN;
             coord[1] = f64::NAN;
             operands.set_coord(i, &coord);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod authoring {
 
     // External material
     pub use log::error;
+    pub use log::debug;
     pub use log::info;
     pub use log::trace;
     pub use log::warn;


### PR DESCRIPTION
This is follow-up PR for #96 issue.

I've checked other places where `warn!` is used, and all the rest instances indicate either projection configuration error or something like wrong number of dimensions in input parameters. So I think it's probably better to leave those as warnings. The changed line is the only place I could find where a warning is issued based on raw values in input data.