### PR TITLE
Improved stack handling

### DIFF
--- a/ruminations/002-rumination.md
+++ b/ruminations/002-rumination.md
@@ -43,6 +43,7 @@ $ echo 553036. -124509 | kp "dms:in | geo:out"
 - [`omerc`](#operator-omerc): The oblique Mercator projection
 - [`pop`](#operator-pop): Pop a dimension from the stack into the operands
 - [`push`](#operator-push): Push a dimension from the operands onto the stack
+- [`stack`](#operator-stack): Push/pop/swap dimensions from the operands onto the stack
 - [`tmerc`](#operator-tmerc): The transverse Mercator projection
 - [`utm`](#operator-utm): The UTM projection
 - [`unitconvert`](#operator-unitconvert): The unit converter
@@ -828,6 +829,8 @@ and RG does not support PROJ's "indirectly given azimuth" case.
 
 ### Operator `pop`
 
+**DEPRECATED!** Use [`stack`](#operator-stack)
+
 **Purpose:** Pop a coordinate dimension from the stack
 
 **Description:**
@@ -842,11 +845,13 @@ Pop the top(s)-of-stack into one or more operand coordinate dimensions. If more 
 
 (the argument names are selected for PROJ compatibility)
 
-**See also:** [`push`](#operator-push)
+**See also:** [`push`](#operator-push),  [`stack`](#operator-stack)
 
 ---
 
 ### Operator `push`
+
+**DEPRECATED!** Use [`stack`](#operator-stack)
 
 **Purpose:** Push a coordinate dimension onto the stack
 
@@ -890,7 +895,42 @@ somerc lat_0=46.9524055555556 lon_0=7.43958333333333 k_0=1 x_0=2600000 y_0=12000
 
 **See also:** [PROJ documentation](https://proj.org/operations/projections/somerc.html): *Swiss Oblique Mercator*.
 
-Note: Rust Geodesy does not support modifying the ellipsoid with and `R` parameter, as PROJ does.
+Note: Rust Geodesy does not support modifying the ellipsoid with an `R` parameter, as PROJ does.
+
+---
+
+### Operator `stack`
+
+**Purpose:** Push/pop/swap coordinate dimensions onto the stack
+
+**Description:**
+Take a copy of one or more coordinate dimensions and push, pop or swap them onto the stack.
+
+
+| Argument   | Description |
+|------------|--------------------------------------------|
+| `push=...` | push a comma separated list of coordinate dimensions onto the stack |
+| `pop=...`  | pop a comma separated list of coordinate dimensions off the stack, into an operand |
+| `swap`     | swap the top-of-stack and the next-to-top-of-stack |
+
+The arguments to `push` and `pop` are handled from left to right, i.e. in latin reading order,
+so the instruction `stack push=1,2` will take the first coordinate element of the operand,
+and push it onto the stack, then on top of that, push the second coordinate element.
+
+Hence, the second coordinate element will occupy the top-of-stack (TOS) position, while
+the first coordinate element will occupy the next-to-top-of-stack (2OS)
+
+If we extend the case to a pipeline:  `stack push=1,2 | stack pop=1,2`, the second part
+will pop material off the stack and into the coordinate elements of the operand in the
+same order as in the push case, i.e. reading its list from left to right.
+
+Hence, the first coordinate element of the operand will get the value of the TOS,
+while the second will get that of the 2OS.
+
+All in all, that amounts to a swapping of the first two coordinate elements of the operand.
+
+
+**See also:** [`pop`](#operator-pop) (deprecated), [`push`](#operator-push) (deprecated)
 
 --
 

--- a/src/inner_op/mod.rs
+++ b/src/inner_op/mod.rs
@@ -25,14 +25,16 @@ mod molodensky;
 mod noop;
 mod omerc;
 pub(crate) mod pipeline; // Needed by Op for instantiation
+mod pushpop;
 mod somerc;
+mod stack;
 mod tmerc;
 mod unitconvert;
 mod units;
 mod webmerc;
 
 #[rustfmt::skip]
-const BUILTIN_OPERATORS: [(&str, OpConstructor); 33] = [
+const BUILTIN_OPERATORS: [(&str, OpConstructor); 34] = [
     ("adapt",        OpConstructor(adapt::new)),
     ("addone",       OpConstructor(addone::new)),
     ("axisswap",     OpConstructor(axisswap::new)),
@@ -61,8 +63,9 @@ const BUILTIN_OPERATORS: [(&str, OpConstructor); 33] = [
 
     // Pipeline handlers
     ("pipeline",     OpConstructor(pipeline::new)),
-    ("pop",          OpConstructor(pipeline::pop)),
-    ("push",         OpConstructor(pipeline::push)),
+    ("pop",          OpConstructor(pushpop::pop)),
+    ("push",         OpConstructor(pushpop::push)),
+    ("stack",        OpConstructor(stack::new)),
 
     // Some commonly used noop-aliases
     ("noop",         OpConstructor(noop::new)),

--- a/src/inner_op/pipeline.rs
+++ b/src/inner_op/pipeline.rs
@@ -1,5 +1,6 @@
+use super::pushpop::{do_the_pop, do_the_push};
+use super::stack::{stack_fwd, stack_inv};
 use crate::authoring::*;
-use std::collections::BTreeSet;
 
 // ----- F O R W A R D -----------------------------------------------------------------
 
@@ -13,6 +14,7 @@ fn pipeline_fwd(op: &Op, ctx: &dyn Context, operands: &mut dyn CoordinateSet) ->
         let m = match step.params.name.as_str() {
             "push" => do_the_push(&mut stack, operands, &step.params.boolean),
             "pop" => do_the_pop(&mut stack, operands, &step.params.boolean),
+            "stack" => stack_fwd(&mut stack, operands, &step.params),
             _ => step.apply(ctx, operands, Fwd),
         };
         n = n.min(m);
@@ -38,6 +40,7 @@ fn pipeline_inv(op: &Op, ctx: &dyn Context, operands: &mut dyn CoordinateSet) ->
         let m = match step.params.name.as_str() {
             "push" => do_the_pop(&mut stack, operands, &step.params.boolean),
             "pop" => do_the_push(&mut stack, operands, &step.params.boolean),
+            "stack" => stack_inv(&mut stack, operands, &step.params),
             _ => step.apply(ctx, operands, Inv),
         };
         n = n.min(m);
@@ -80,109 +83,6 @@ pub fn new(parameters: &RawParameters, ctx: &dyn Context) -> Result<Op, Error> {
     })
 }
 
-// The push and pop constructors are extremely simple, since the pipeline operator
-// does all the hard work. Essentially, they are just flags telling pipeline
-// what to do, given their provided options
-
-// Yes - push and pop do not accept the inv flag although they are both invertible.
-// If you want to invert a push, then use a pop (and vice versa).
-#[rustfmt::skip]
-pub const PUSH_POP_GAMUT: [OpParameter; 4] = [
-    OpParameter::Flag { key: "v_1" },
-    OpParameter::Flag { key: "v_2" },
-    OpParameter::Flag { key: "v_3" },
-    OpParameter::Flag { key: "v_4" },
-];
-
-pub fn push(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> {
-    let def = &parameters.definition;
-    let params = ParsedParameters::new(parameters, &PUSH_POP_GAMUT)?;
-
-    let descriptor = OpDescriptor::new(def, InnerOp::default(), Some(InnerOp::default()));
-    let steps = Vec::new();
-    let id = OpHandle::new();
-
-    Ok(Op {
-        descriptor,
-        params,
-        steps,
-        id,
-    })
-}
-
-pub fn pop(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> {
-    let def = &parameters.definition;
-    let params = ParsedParameters::new(parameters, &PUSH_POP_GAMUT)?;
-
-    let descriptor = OpDescriptor::new(def, InnerOp::default(), Some(InnerOp::default()));
-    let steps = Vec::new();
-    let id = OpHandle::new();
-
-    Ok(Op {
-        descriptor,
-        params,
-        steps,
-        id,
-    })
-}
-
-// ----- H E L P E R S -----------------------------------------------------------------
-
-fn do_the_push(
-    stack: &mut Vec<Vec<f64>>,
-    operands: &mut dyn CoordinateSet,
-    flags: &BTreeSet<&'static str>,
-) -> usize {
-    let n = operands.len();
-    const ELEMENTS: [&str; 4] = ["v_1", "v_2", "v_3", "v_4"];
-    for j in [0, 1, 2, 3] {
-        if !flags.contains(ELEMENTS[j]) {
-            continue;
-        }
-
-        let mut all = Vec::with_capacity(n);
-        for i in 0..n {
-            all.push(operands.get_coord(i)[j]);
-        }
-        stack.push(all);
-    }
-    operands.len()
-}
-
-fn do_the_pop(
-    stack: &mut Vec<Vec<f64>>,
-    operands: &mut dyn CoordinateSet,
-    flags: &BTreeSet<&'static str>,
-) -> usize {
-    let n = operands.len();
-    const ELEMENTS: [&str; 4] = ["v_4", "v_3", "v_2", "v_1"];
-    for j in [0, 1, 2, 3] {
-        if !flags.contains(ELEMENTS[j]) {
-            continue;
-        }
-
-        // Stack underflow?
-        if stack.is_empty() {
-            for i in 0..n {
-                let mut op = operands.get_coord(i);
-                op[3 - j] = f64::NAN;
-                operands.set_coord(i, &op);
-            }
-            warn!("Stack underflow in pipeline");
-            return 0;
-        }
-
-        // Insert the top-of-stack elements into the j'th coordinate of all operands
-        let v = stack.pop().unwrap();
-        for (i, value) in v.iter().enumerate() {
-            let mut op = operands.get_coord(i);
-            op[3 - j] = *value;
-            operands.set_coord(i, &op);
-        }
-    }
-    operands.len()
-}
-
 // ----- T E S T S ---------------------------------------------------------------------
 
 #[cfg(test)]
@@ -220,61 +120,6 @@ mod tests {
             ctx.op("addone|addone|_garbage"),
             Err(Error::NotFound(_, _))
         ));
-
-        Ok(())
-    }
-
-    #[test]
-    fn push_pop() -> Result<(), Error> {
-        let mut ctx = Minimal::default();
-        let mut data = some_basic_coor3dinates();
-
-        // First we swap lat, lon by doing two independent pops
-        let op = ctx.op("push v_2 v_1|addone|pop v_1|pop v_2")?;
-        ctx.apply(op, Fwd, &mut data)?;
-        assert_eq!(data[0][0], 12.);
-        assert_eq!(data[0][1], 55.);
-
-        // While popping both at once does not make any difference: In
-        // case of more than one push/pop argument, push happens in
-        // 1234-order, while pop happens in 4321-order, so a
-        // "push all, pop all" pair is a noop: The order of operator
-        // options is insignificant, so the 1234/4321 order is, in principle
-        // arbitrary, but selected with the noop-characteristics in mind.
-        let op = ctx.op("push v_1 v_2|pop v_1 v_2")?;
-        ctx.apply(op, Fwd, &mut data)?;
-        assert_eq!(data[0][0], 12.);
-        assert_eq!(data[0][1], 55.);
-
-        // Underflow the stack - get 0 successes
-        let op = ctx.op("push v_1 v_2|pop v_2 v_1 v_3")?;
-        assert_eq!(0, ctx.apply(op, Fwd, &mut data)?);
-        assert!(data[0][0].is_nan());
-        assert_eq!(data[0][2], 55.);
-
-        // Check inversion
-        let op = ctx.op("push v_1 v_2|pop v_2 v_1 v_3")?;
-        let mut data = some_basic_coor3dinates();
-        assert_eq!(2, ctx.apply(op, Inv, &mut data)?);
-        assert_eq!(data[0][0], 12.);
-        assert_eq!(data[0][1], 0.);
-
-        // Check omit_fwd
-        let op = ctx.op("push v_1 v_2|pop v_2 v_1 v_3 omit_fwd")?;
-        let mut data = some_basic_coor3dinates();
-        assert_eq!(2, ctx.apply(op, Fwd, &mut data)?);
-        assert_eq!(data[0][0], 55.);
-        assert_eq!(data[0][1], 12.);
-        assert_eq!(2, ctx.apply(op, Inv, &mut data)?);
-        assert_eq!(data[0][0], 12.);
-        assert_eq!(data[0][1], 0.);
-
-        // Check omit_inv
-        let op = ctx.op("push v_1 v_2 v_3 omit_inv|pop v_1 v_2")?;
-        let mut data = some_basic_coor3dinates();
-        assert_eq!(2, ctx.apply(op, Inv, &mut data)?);
-        assert_eq!(data[0][0], 55.);
-        assert_eq!(data[0][1], 12.);
 
         Ok(())
     }

--- a/src/inner_op/pushpop.rs
+++ b/src/inner_op/pushpop.rs
@@ -1,0 +1,167 @@
+/// Deprecated version of the stack functionality for pipelines
+/// DO NOT USE THIS. Use "stack push=...", "stack pop=..." etc.
+use crate::authoring::*;
+use std::collections::BTreeSet;
+
+// The push and pop constructors are extremely simple, since the pipeline operator
+// does all the hard work. Essentially, they are just flags telling pipeline
+// what to do, given their provided options
+
+// Yes - push and pop do not accept the inv flag although they are both invertible.
+// If you want to invert a push, then use a pop (and vice versa).
+#[rustfmt::skip]
+pub const PUSH_POP_GAMUT: [OpParameter; 4] = [
+    OpParameter::Flag { key: "v_1" },
+    OpParameter::Flag { key: "v_2" },
+    OpParameter::Flag { key: "v_3" },
+    OpParameter::Flag { key: "v_4" },
+];
+
+pub fn push(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> {
+    let def = &parameters.definition;
+    let params = ParsedParameters::new(parameters, &PUSH_POP_GAMUT)?;
+
+    let descriptor = OpDescriptor::new(def, InnerOp::default(), Some(InnerOp::default()));
+    let steps = Vec::new();
+    let id = OpHandle::new();
+
+    Ok(Op {
+        descriptor,
+        params,
+        steps,
+        id,
+    })
+}
+
+pub fn pop(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> {
+    let def = &parameters.definition;
+    let params = ParsedParameters::new(parameters, &PUSH_POP_GAMUT)?;
+
+    let descriptor = OpDescriptor::new(def, InnerOp::default(), Some(InnerOp::default()));
+    let steps = Vec::new();
+    let id = OpHandle::new();
+
+    Ok(Op {
+        descriptor,
+        params,
+        steps,
+        id,
+    })
+}
+
+pub(super) fn do_the_push(
+    stack: &mut Vec<Vec<f64>>,
+    operands: &mut dyn CoordinateSet,
+    flags: &BTreeSet<&'static str>,
+) -> usize {
+    let n = operands.len();
+    const ELEMENTS: [&str; 4] = ["v_1", "v_2", "v_3", "v_4"];
+    for j in [0, 1, 2, 3] {
+        if !flags.contains(ELEMENTS[j]) {
+            continue;
+        }
+
+        let mut all = Vec::with_capacity(n);
+        for i in 0..n {
+            all.push(operands.get_coord(i)[j]);
+        }
+        stack.push(all);
+    }
+    operands.len()
+}
+
+pub(super) fn do_the_pop(
+    stack: &mut Vec<Vec<f64>>,
+    operands: &mut dyn CoordinateSet,
+    flags: &BTreeSet<&'static str>,
+) -> usize {
+    let n = operands.len();
+    const ELEMENTS: [&str; 4] = ["v_4", "v_3", "v_2", "v_1"];
+    for j in [0, 1, 2, 3] {
+        if !flags.contains(ELEMENTS[j]) {
+            continue;
+        }
+
+        // Stack underflow?
+        if stack.is_empty() {
+            for i in 0..n {
+                let mut op = operands.get_coord(i);
+                op[3 - j] = f64::NAN;
+                operands.set_coord(i, &op);
+            }
+            warn!("Stack underflow in pipeline");
+            return 0;
+        }
+
+        // Insert the top-of-stack elements into the j'th coordinate of all operands
+        let v = stack.pop().unwrap();
+        for (i, value) in v.iter().enumerate() {
+            let mut op = operands.get_coord(i);
+            op[3 - j] = *value;
+            operands.set_coord(i, &op);
+        }
+    }
+    operands.len()
+}
+
+// ----- T E S T S ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_pop() -> Result<(), Error> {
+        let mut ctx = Minimal::default();
+        let mut data = some_basic_coor3dinates();
+
+        // First we swap lat, lon by doing two independent pops
+        let op = ctx.op("push v_2 v_1|addone|pop v_1|pop v_2")?;
+        ctx.apply(op, Fwd, &mut data)?;
+        assert_eq!(data[0][0], 12.);
+        assert_eq!(data[0][1], 55.);
+
+        // While popping both at once does not make any difference: In
+        // case of more than one push/pop argument, push happens in
+        // 1234-order, while pop happens in 4321-order, so a
+        // "push all, pop all" pair is a noop: The order of operator
+        // options is insignificant, so the 1234/4321 order is, in principle
+        // arbitrary, but selected with the noop-characteristics in mind.
+        let op = ctx.op("push v_1 v_2|pop v_1 v_2")?;
+        ctx.apply(op, Fwd, &mut data)?;
+        assert_eq!(data[0][0], 12.);
+        assert_eq!(data[0][1], 55.);
+
+        // Underflow the stack - get 0 successes
+        let op = ctx.op("push v_1 v_2|pop v_2 v_1 v_3")?;
+        assert_eq!(0, ctx.apply(op, Fwd, &mut data)?);
+        assert!(data[0][0].is_nan());
+        assert_eq!(data[0][2], 55.);
+
+        // Check inversion
+        let op = ctx.op("push v_1 v_2|pop v_2 v_1 v_3")?;
+        let mut data = some_basic_coor3dinates();
+        assert_eq!(2, ctx.apply(op, Inv, &mut data)?);
+        assert_eq!(data[0][0], 12.);
+        assert_eq!(data[0][1], 0.);
+
+        // Check omit_fwd
+        let op = ctx.op("push v_1 v_2|pop v_2 v_1 v_3 omit_fwd")?;
+        let mut data = some_basic_coor3dinates();
+        assert_eq!(2, ctx.apply(op, Fwd, &mut data)?);
+        assert_eq!(data[0][0], 55.);
+        assert_eq!(data[0][1], 12.);
+        assert_eq!(2, ctx.apply(op, Inv, &mut data)?);
+        assert_eq!(data[0][0], 12.);
+        assert_eq!(data[0][1], 0.);
+
+        // Check omit_inv
+        let op = ctx.op("push v_1 v_2 v_3 omit_inv|pop v_1 v_2")?;
+        let mut data = some_basic_coor3dinates();
+        assert_eq!(2, ctx.apply(op, Inv, &mut data)?);
+        assert_eq!(data[0][0], 55.);
+        assert_eq!(data[0][1], 12.);
+
+        Ok(())
+    }
+}

--- a/src/inner_op/stack.rs
+++ b/src/inner_op/stack.rs
@@ -1,0 +1,347 @@
+/// Stack functionality for pipelines (push/pop/swap)
+use crate::authoring::*;
+
+// NOTE: roll and drop are not implemented yet
+#[rustfmt::skip]
+pub const STACK_GAMUT: [OpParameter; 5] = [
+    OpParameter::Series  { key: "push", default: Some("") },
+    OpParameter::Series  { key: "pop",  default: Some("") },
+    OpParameter::Series  { key: "roll", default: Some("") },
+    OpParameter::Flag    { key: "swap" },
+    OpParameter::Flag    { key: "drop" },
+];
+
+/// Construct a new stack operator. Check the syntax and semantics
+pub fn new(parameters: &RawParameters, _ctx: &dyn Context) -> Result<Op, Error> {
+    let def = &parameters.definition;
+    let mut params = ParsedParameters::new(parameters, &STACK_GAMUT)?;
+
+    // The subcommands (push, pop, roll, swap, drop) are mutually exclusive,
+    // so we count them and err if more than one is given
+    let mut subcommands_given: usize = 0;
+
+    // The arguments to push and pop are specified as a series, but Geodesy
+    // series are represented internally as a Vec<f64>, so the valid
+    // coordinate indices (1..4, i.e. the max coordinate dimensionality)
+    // are also stored as f64, to simplify comparison
+    let valid_indices = [1., 2., 3., 4.];
+
+    // Now do a sanity check for all subcommands
+
+    if let Ok(push_args) = params.series("push") {
+        subcommands_given += 1;
+        for i in push_args.iter() {
+            if !valid_indices.contains(i) {
+                return Err(Error::BadParam("push".to_string(), i.to_string()));
+            }
+        }
+        params.text.insert("action", "push".to_string());
+    }
+
+    if let Ok(pop_args) = params.series("pop") {
+        subcommands_given += 1;
+        for i in pop_args.iter() {
+            if !valid_indices.contains(i) {
+                return Err(Error::BadParam("pop".to_string(), i.to_string()));
+            }
+        }
+        params.text.insert("action", "pop".to_string());
+    }
+
+    if let Ok(roll_args) = params.series("roll") {
+        subcommands_given += 1;
+        if roll_args.len() != 2
+            || roll_args[0].fract() != 0.
+            || roll_args[1].fract() != 0.
+            || roll_args[0] < roll_args[1].abs()
+        {
+            return Err(Error::MissingParam(
+                "roll takes exactly two integer parameters".to_string(),
+            ));
+        }
+        params.text.insert("action", "roll".to_string());
+    }
+
+    if params.boolean("swap") {
+        subcommands_given += 1;
+        params.text.insert("action", "swap".to_string());
+    }
+
+    if params.boolean("drop") {
+        subcommands_given += 1;
+        params.text.insert("action", "drop".to_string());
+    }
+
+    if subcommands_given != 1 {
+        return Err(Error::MissingParam(
+            "stack: must specify exactly one of push/pop/roll/swap/drop".to_string(),
+        ));
+    }
+
+    // The true action is handled by 'pipeline', so the `InnerOp`s are placeholders
+    let descriptor = OpDescriptor::new(def, InnerOp::default(), Some(InnerOp::default()));
+    let steps = Vec::new();
+    let id = OpHandle::new();
+
+    Ok(Op {
+        descriptor,
+        params,
+        steps,
+        id,
+    })
+}
+
+/// Called by `pipeline_fwd` to execute stack operations in forward mode
+pub(super) fn stack_fwd(
+    stack: &mut Vec<Vec<f64>>,
+    operands: &mut dyn CoordinateSet,
+    params: &ParsedParameters,
+) -> usize {
+    let Some(action) = params.text.get("action") else {
+        return 0;
+    };
+
+    let successes = match action.as_str() {
+        "push" => {
+            // Turn f64 dimensions 1-4 into usize indices 0-3
+            let args: Vec<usize> = params
+                .series("push")
+                .unwrap()
+                .iter()
+                .map(|i| *i as usize - 1)
+                .collect();
+            stack_push(stack, operands, &args)
+        }
+
+        "pop" => {
+            // Turn f64 dimensions 1-4 into usize indices 0-3
+            let args: Vec<usize> = params
+                .series("pop")
+                .unwrap()
+                .iter()
+                .map(|i| *i as usize - 1)
+                .collect();
+            stack_pop(stack, operands, &args)
+        }
+
+        "swap" => {
+            let n = stack.len();
+            if n > 1 {
+                stack.swap(n - 1, n - 2)
+            }
+            if n == 0 {
+                0
+            } else {
+                stack[0].len()
+            }
+        }
+
+        _ => 0,
+    };
+
+    successes
+}
+
+/// Called by `pipeline_inv` to execute stack operations in inverse mode.
+/// Inverse mode has two major differences from forward: push and pop switches
+/// functionality, and their argument order swaps direction
+pub(super) fn stack_inv(
+    stack: &mut Vec<Vec<f64>>,
+    operands: &mut dyn CoordinateSet,
+    params: &ParsedParameters,
+) -> usize {
+    let Some(action) = params.text.get("action") else {
+        return 0;
+    };
+
+    let successes = match action.as_str() {
+        "push" => {
+            // Turn f64 dimensions 1-4 into **reversed** usize indices 0-3  ******
+            let args: Vec<usize> = params
+                .series("push")
+                .unwrap()
+                .iter()
+                .rev()
+                .map(|i| *i as usize - 1)
+                .collect();
+            stack_pop(stack, operands, &args)
+        }
+
+        "pop" => {
+            // Turn f64 dimensions 1-4 into **reversed** usize indices 0-3
+            let args: Vec<usize> = params
+                .series("pop")
+                .unwrap()
+                .iter()
+                .rev()
+                .map(|i| *i as usize - 1)
+                .collect();
+            return stack_push(stack, operands, &args);
+        }
+
+        "swap" => {
+            let n = stack.len();
+            if n > 1 {
+                stack.swap(n - 1, n - 2)
+            }
+            if n == 0 {
+                0
+            } else {
+                stack[0].len()
+            }
+        }
+
+        _ => 0,
+    };
+
+    successes
+}
+
+/// Push elements from a CoordinateSet onto the stack
+fn stack_push(
+    stack: &mut Vec<Vec<f64>>,
+    operands: &mut dyn CoordinateSet,
+    args: &[usize],
+) -> usize {
+    let number_of_pushes = args.len();
+    let number_of_operands = operands.len();
+
+    // Make room for the new sets of elements to be pushed on to the stack
+    let mut ext = vec![vec![0f64; number_of_operands]; number_of_pushes];
+
+    // Extract the coordinate elements into the new stack elements
+    for i in 0..number_of_operands {
+        let coord = operands.get_coord(i);
+        for j in 0..number_of_pushes {
+            ext[j][i] = coord[args[j]];
+        }
+    }
+
+    // And push them onto the existing stack
+    stack.extend(ext);
+    number_of_operands
+}
+
+/// Pop elements from the stack into elements of a CoordinateSet
+fn stack_pop(stack: &mut Vec<Vec<f64>>, operands: &mut dyn CoordinateSet, args: &[usize]) -> usize {
+    let number_of_pops = args.len();
+    let number_of_operands = operands.len();
+    let stack_depth = stack.len();
+
+    // In case of underflow, we stomp on all input coordinates
+    if stack_depth < number_of_pops {
+        warn!("Stack underflow in pipeline");
+        let nanny = Coor4D::nan();
+        for i in 0..number_of_operands {
+            operands.set_coord(i, &nanny);
+        }
+        return 0;
+    }
+
+    // Remove the correct number of elements and obtain a reversed version.
+    // Incidentally, this is both the easiest way to obtain the popped
+    // subset, and the easiest way to make the top-of-stack (i.e. the
+    // element first popped) have the index 0, which makes the 'for j...'
+    // loop below slightly more straightforward
+    let mut ext = Vec::with_capacity(number_of_pops);
+    for _ in args {
+        ext.push(stack.pop().unwrap());
+    }
+
+    // Extract the required stack elements into the proper
+    // positions of the coordinate elements
+    for i in 0..number_of_operands {
+        let mut coord = operands.get_coord(i);
+        for j in 0..number_of_pops {
+            coord[args[j]] = ext[j][i];
+        }
+        operands.set_coord(i, &coord);
+    }
+
+    number_of_operands
+}
+
+// ----- T E S T S ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stack() -> Result<(), Error> {
+        let mut ctx = Minimal::default();
+        let master_data = vec![Coor4D([11., 12., 13., 14.]), Coor4D([21., 22., 23., 24.])];
+
+        // ----- Three initial sanity checks -----
+
+        // Yes, we may push any number of elements onto the stack. And
+        // no, I do not see any immediate actual uses for this, but
+        // disallowing it would require more code, more complicated code,
+        // all for no gain other than stomping on a potential future use
+        // case
+        assert!(ctx.op("stack push=2,2,1,1,3,3,4,4,4,4,4,4,4").is_ok());
+
+        // But we must not have more than one subcommand for each
+        // stack operator
+        assert!(ctx.op("stack push=2,2,1,1 pop=1,1,2").is_err());
+
+        // ...while in two consecutive steps it works as it should
+        // (the push/pop-imbalance is not an error. Again a potential
+        // use case, that would require code complication to disallow)
+        assert!(ctx.op("stack push=2,2,1,1 | stack pop=1,1,2").is_ok());
+
+        // ----- Three tests of the actual functionality -----
+
+        let mut data = master_data.clone();
+
+        // 1: Swap the first and second coordinate dimensions by a push/pop dance
+
+        // Explanation:
+        // The first step pushes the first and second coordinate of
+        // the operand onto the stack **in that order**.
+        // Hence,
+        // - The second coordinate becomes top-of-stack (TOS), as
+        //   it is the last one pushed, and
+        // - The first coordinate becomes second-of-stack (2OS)
+        //
+        // The second step pops the TOS into the first coordinate of
+        // the operand, and the 2OS into the first coordinate of the
+        // operand
+        let op = ctx.op("stack push=1,2|stack pop=1,2")?;
+        ctx.apply(op, Fwd, &mut data)?;
+        assert_eq!(data[0][0], 12.);
+        assert_eq!(data[1][1], 21.);
+
+        // Then we do the inverse
+        ctx.apply(op, Inv, &mut data)?;
+        assert_eq!(data[0], master_data[0]);
+        assert_eq!(data[1], master_data[1]);
+
+        // 2: An exercise in reverse thinking - doing the inverse call first
+
+        let op = ctx.op("stack push=2,1 | stack pop=2,1")?;
+        // The inverse call should in effect execute "stack push=1,2 | stack pop=1,2"
+        ctx.apply(op, Inv, &mut data)?;
+        assert_eq!(data[0][0], 12.);
+        assert_eq!(data[1][1], 21.);
+
+        // Then we do the inverse
+        ctx.apply(op, Fwd, &mut data)?;
+        assert_eq!(data[0], master_data[0]);
+        assert_eq!(data[1], master_data[1]);
+
+        // 3: Test the `swap` subcommand
+
+        let op = ctx.op("stack push=2,1 | stack swap | stack pop=1,2")?;
+        ctx.apply(op, Fwd, &mut data)?;
+        assert_eq!(data[0][0], 12.);
+        assert_eq!(data[1][1], 21.);
+
+        // Then we do the inverse
+        ctx.apply(op, Inv, &mut data)?;
+        assert_eq!(data[0], master_data[0]);
+        assert_eq!(data[1], master_data[1]);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
The push/pop componenents, modelled after their PROJ namesakes, are suboptimal. To remedy this a new implementation, `stack` is introduced, with subcommands for pushing, popping and swapping.

Work on adding dropping and rolling is in progress.