### PR TITLE
Trait based refactor of Ellipsoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- CoordinateSet: xyz(), set_xyz(), xyzt(), set_xyzt() methods
+- `CoordinateSet`: xyz(), set_xyz(), xyzt(), set_xyzt() methods
 - Vector space operators (Add, Sub, Mul, Div) for all built
   in coordinate tuple types (Coor4D, Coor3D, Coor2D, Coor32)
+- `TriaxialEllpisoid`, mostly as a placeholder
 
 ### Changed
 
 - `CoordinateTuple` trait now requires implementation of the constructor
   method `new(fill: f64)`, returning an object of `dim()` copies of `fill`.
+- The huge `Ellipsoid`-implementation switched to a new trait `EllipsoidBase`,
+  and a number of associated traits requiring `EllipsoidBase`.
+- Meaning of `EllipsoidBase::aspect_ratio()` switched from *b / a* to the
+  apparently more common *a / b*
+- Major restructuring and clean up of `lib.rs`. Only marignally visible externally,
+  if using `use geodesy::prelude::*`
 
 ### Removed
 

--- a/examples/03-user_defined_operators.rs
+++ b/examples/03-user_defined_operators.rs
@@ -51,7 +51,7 @@ pub fn add42_constructor(parameters: &RawParameters, ctx: &dyn Context) -> Resul
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut prv = geodesy::Minimal::new();
+    let mut prv = geodesy::prelude::Minimal::new();
     prv.register_op("add42", OpConstructor(add42_constructor));
     let add42 = prv.op("add42")?;
 

--- a/examples/05-pq.rs
+++ b/examples/05-pq.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // We use ::new() instead of ::default() in order to gain access to the
     // BUILTIN_ADAPTORS
-    let mut ctx = geodesy::Minimal::new();
+    let mut ctx = geodesy::prelude::Minimal::new();
     trace!("trace message 2");
     debug!("debug message 2");
 

--- a/examples/06-user_defined_coordinate_types_and_containers.rs
+++ b/examples/06-user_defined_coordinate_types_and_containers.rs
@@ -87,7 +87,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // We use ::new() instead of ::default() in order to gain access to the
     // BUILTIN_ADAPTORS (geo:in, geo:out etc.)
-    let mut ctx = geodesy::Minimal::new();
+    let mut ctx = geodesy::prelude::Minimal::new();
     trace!("have context");
 
     let copenhagen = Coor4D([55., 12., 0., 0.]);

--- a/examples/08-user_defined_operators_using_proj.rs
+++ b/examples/08-user_defined_operators_using_proj.rs
@@ -171,7 +171,7 @@ pub fn proj_constructor(parameters: &RawParameters, _ctx: &dyn Context) -> Resul
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut prv = geodesy::Minimal::new();
+    let mut prv = geodesy::prelude::Minimal::new();
     prv.register_op("proj", OpConstructor(proj_constructor));
     let e = Ellipsoid::default();
 

--- a/src/coordinate/coor32.rs
+++ b/src/coordinate/coor32.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Generic 2D Coordinate tuple, with no fixed interpretation of the elements.
-/// A tiny coordinate type: Just one fourth the weight of a [`Coor4D`](crate::Coor4D).
+/// A tiny coordinate type: Just one fourth the weight of a [`Coor4D`](super::Coor4D).
 /// Probably only useful for small scale world maps, without too much zoom.
 #[derive(Debug, Default, PartialEq, Copy, Clone)]
 pub struct Coor32(pub [f32; 2]);

--- a/src/coordinate/mod.rs
+++ b/src/coordinate/mod.rs
@@ -63,7 +63,7 @@ where
 }
 
 /// For Rust Geodesy, the ISO-19111 concept of `DirectPosition` is represented
-/// as a `geodesy::Coo4D`.
+/// as a `geodesy::Coor4D`.
 ///
 /// The strict connection between the ISO19107 "DirectPosition" datatype
 /// and the ISO19111/OGC Topic 2 "CoordinateSet" interface (i.e. trait)

--- a/src/coordinate/tuple.rs
+++ b/src/coordinate/tuple.rs
@@ -109,7 +109,7 @@ all_coord_operators!(Coor32, Coor32, coor32);
 
 /// CoordinateTuple is the ISO-19111 atomic spatial/spatiotemporal
 /// referencing element. So loosely speaking, a CoordinateSet is a
-///  collection of CoordinateTuples.
+/// collection of CoordinateTuples.
 ///
 /// Note that (despite the formal name) the underlying data structure
 /// need not be a tuple: It can be any item, for which it makes sense
@@ -357,7 +357,7 @@ pub trait CoordinateTuple {
     /// # See also:
     ///
     /// [`hypot3`](Self::hypot3),
-    /// [`distance`](crate::ellipsoid::Ellipsoid::distance)
+    /// [`distance`](crate::ellps::Geodesics::distance)
     ///
     /// # Examples
     ///
@@ -391,7 +391,7 @@ pub trait CoordinateTuple {
     /// # See also:
     ///
     /// [`hypot2()`](Self::hypot2),
-    /// [`distance`](crate::ellipsoid::Ellipsoid::distance)
+    /// [`distance`](crate::ellps::Geodesics::distance)
     ///
     /// # Examples
     ///

--- a/src/ellipsoid/biaxial.rs
+++ b/src/ellipsoid/biaxial.rs
@@ -1,0 +1,99 @@
+use crate::prelude::*;
+
+/// An ellipsoid of revolution.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Ellipsoid {
+    a: f64,
+    f: f64,
+}
+
+/// GRS80 is the default ellipsoid.
+impl Default for Ellipsoid {
+    fn default() -> Ellipsoid {
+        Ellipsoid::new(6_378_137.0, 1. / 298.257_222_100_882_7)
+    }
+}
+
+impl EllipsoidBase for Ellipsoid {
+    fn semimajor_axis(&self) -> f64 {
+        self.a
+    }
+
+    fn flattening(&self) -> f64 {
+        self.f
+    }
+}
+
+/// Constructors for `Ellipsoid`
+impl Ellipsoid {
+    /// User defined ellipsoid
+    #[must_use]
+    pub fn new(semimajor_axis: f64, flattening: f64) -> Ellipsoid {
+        Ellipsoid {
+            a: semimajor_axis,
+            f: flattening,
+        }
+    }
+
+    /// Predefined ellipsoid; built-in, defined in asset collections, or given as a
+    /// string formatted (a, rf) tuple, e.g. "6378137, 298.25"
+    pub fn named(name: &str) -> Result<Ellipsoid, Error> {
+        // Is it one of the few builtins?
+        if let Some(index) = super::constants::ELLIPSOID_LIST
+            .iter()
+            .position(|&ellps| ellps.0 == name)
+        {
+            let e = super::constants::ELLIPSOID_LIST[index];
+            let ax: f64 = e.1.parse().unwrap();
+            let rf: f64 = e.3.parse().unwrap();
+            // EPSG convention: zero reciproque flattening indicates zero flattening
+            let f = if rf != 0.0 { 1.0 / rf } else { rf };
+            return Ok(Ellipsoid::new(ax, f));
+        }
+
+        // The "semimajor, reciproque-flattening" form, e.g. "6378137, 298.3"
+        let a_and_rf = name.split(',').collect::<Vec<_>>();
+        if a_and_rf.len() == 2_usize {
+            if let Ok(a) = a_and_rf[0].trim().parse::<f64>() {
+                if let Ok(rf) = a_and_rf[1].trim().parse::<f64>() {
+                    return Ok(Ellipsoid::new(a, 1. / rf));
+                }
+            }
+        }
+
+        // TODO: Search asset collection
+        Err(Error::NotFound(
+            String::from(name),
+            String::from("Ellipsoid::named()"),
+        ))
+    }
+}
+
+// ----- Tests ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::ellps::Ellipsoid;
+    use crate::ellps::EllipsoidBase;
+    use crate::ellps::Meridians;
+    use crate::Error;
+
+    #[test]
+    fn test_ellipsoid() -> Result<(), Error> {
+        // Constructors
+        let ellps = Ellipsoid::named("intl")?;
+        assert_eq!(ellps.flattening(), 1. / 297.);
+
+        let ellps = Ellipsoid::named("6378137, 298.25")?;
+        assert_eq!(ellps.semimajor_axis(), 6378137.0);
+        assert_eq!(ellps.flattening(), 1. / 298.25);
+
+        let ellps = Ellipsoid::named("GRS80")?;
+        assert_eq!(ellps.semimajor_axis(), 6378137.0);
+        assert_eq!(ellps.flattening(), 1. / 298.257_222_100_882_7);
+
+        assert!((ellps.normalized_meridian_arc_unit() - 0.998_324_298_423_041_5).abs() < 1e-13);
+        assert!((4.0 * ellps.meridian_quadrant() - 40_007_862.916_921_8).abs() < 1e-7);
+        Ok(())
+    }
+}

--- a/src/ellipsoid/gravity.rs
+++ b/src/ellipsoid/gravity.rs
@@ -8,17 +8,12 @@ use super::*;
 /// Currently they remain untested in the absolute sense of the word:
 /// The test suite checks for regressions, but the values used for comparison
 /// are entirely internally sourced.
-impl Ellipsoid {
+pub trait Gravity: EllipsoidBase {
     /// The Somigliana normal gravity formula. If the equatorial
     /// normal gravity, gamma_a, and/or the polar normal gravity,
     /// gamma_b, is given as `None`, the values for GRS80 is used.
     #[must_use]
-    pub fn somigliana_gravity(
-        &self,
-        latitude: f64,
-        gamma_a: Option<f64>,
-        gamma_b: Option<f64>,
-    ) -> f64 {
+    fn somigliana_gravity(&self, latitude: f64, gamma_a: Option<f64>, gamma_b: Option<f64>) -> f64 {
         let ga = gamma_a.unwrap_or(9.780_326_771_5);
         let gb = gamma_b.unwrap_or(9.832_186_368_5);
 
@@ -36,7 +31,7 @@ impl Ellipsoid {
     /// international (Hayford) ellipsoid (or for mis-use with
     /// any other ellipsoid)
     #[must_use]
-    pub fn cassinis_gravity_1930(&self, latitude: f64) -> f64 {
+    fn cassinis_gravity_1930(&self, latitude: f64) -> f64 {
         const GAMMA_A: f64 = 9.780_49;
         const BETA_1: f64 = 5.2884e-3;
         const BETA_2: f64 = 5.9e-6;
@@ -49,7 +44,7 @@ impl Ellipsoid {
     /// Harold Jeffreys' 1948 improvement to the international
     /// gravity formula 1930
     #[must_use]
-    pub fn jeffreys_gravity_1948(&self, latitude: f64) -> f64 {
+    fn jeffreys_gravity_1948(&self, latitude: f64) -> f64 {
         const GAMMA_A: f64 = 9.780_373;
         const BETA_1: f64 = 5.2884e-3;
         const BETA_2: f64 = 5.9e-6;
@@ -61,7 +56,7 @@ impl Ellipsoid {
 
     /// The GRS67 gravity formula. Differs from GRS80 at the mgal level
     #[must_use]
-    pub fn grs67_gravity(&self, latitude: f64) -> f64 {
+    fn grs67_gravity(&self, latitude: f64) -> f64 {
         const GAMMA_A: f64 = 9.780_318;
         const BETA_1: f64 = 5.3024e-3;
         const BETA_2: f64 = 5.9e-6;
@@ -74,7 +69,7 @@ impl Ellipsoid {
     /// The international gravity formula 1980, for use with
     /// systems based on GRS80
     #[must_use]
-    pub fn grs80_gravity(&self, latitude: f64) -> f64 {
+    fn grs80_gravity(&self, latitude: f64) -> f64 {
         // Equatorial normal gravity [m/s²]
         const GAMMA_A: f64 = 9.780_326_771_5;
         const C1: f64 = 5.279_041_4e-3;
@@ -90,7 +85,7 @@ impl Ellipsoid {
     /// density (in kg/m³). The value is to be **subtracted** from the
     /// normal gravity on the ellipsoid.
     #[must_use]
-    pub fn cassinis_height_correction(&self, height: f64, density: f64) -> f64 {
+    fn cassinis_height_correction(&self, height: f64, density: f64) -> f64 {
         (3.08e-6 - 4.19e-10 * density) * height
     }
 
@@ -98,7 +93,7 @@ impl Ellipsoid {
     /// The value is to be **subtracted** from the normal gravity on the
     /// ellipsoid.
     #[must_use]
-    pub fn grs67_height_correction(&self, latitude: f64, height: f64) -> f64 {
+    fn grs67_height_correction(&self, latitude: f64, height: f64) -> f64 {
         ((3.0877e-6 - 4.3e-9 * latitude.sin().powi(2)) + 7.2e-13 * height) * height
     }
 
@@ -117,7 +112,7 @@ impl Ellipsoid {
     /// individual observations? - or perhaps the HandWiki text is just slightly
     /// wrong here.
     #[must_use]
-    pub fn welmec(&self, latitude: f64, height: f64) -> f64 {
+    fn welmec(&self, latitude: f64, height: f64) -> f64 {
         let s1 = latitude.sin().powi(2);
         let s2 = (latitude * 2.).sin().powi(2);
         (1.0 + 0.0053024 * s1 - 0.0000058 * s2) * 9.780318 - 0.000003085 * height

--- a/src/ellipsoid/meridians.rs
+++ b/src/ellipsoid/meridians.rs
@@ -1,8 +1,8 @@
 use super::*;
 use std::f64::consts::FRAC_PI_2;
 
-// ----- Meridian geometry -----------------------------------------------------
-impl Ellipsoid {
+/// Meridian geometry
+pub trait Meridians: EllipsoidBase {
     /// The Normalized Meridian Arc Unit, *Qn*, is the mean length of one radian
     ///  of the meridian. "Normalized", because we measure it in units of the
     /// semimajor axis, *a*.
@@ -10,7 +10,7 @@ impl Ellipsoid {
     /// König und Weise p.50 (96), p.19 (38b), p.5 (2), here using the extended
     /// version from [Karney 2010](crate::Bibliography::Kar10) eq. (29)
     #[must_use]
-    pub fn normalized_meridian_arc_unit(&self) -> f64 {
+    fn normalized_meridian_arc_unit(&self) -> f64 {
         let n = self.third_flattening();
         crate::math::taylor::horner(n * n, &constants::MERIDIAN_ARC_COEFFICIENTS) / (1. + n)
     }
@@ -18,12 +18,12 @@ impl Ellipsoid {
     /// The rectifying radius, *A*, is the radius of a sphere of the same circumference
     /// as the length of a full meridian on the ellipsoid.
     ///
-    /// Closely related to the [normalized meridian arc unit](Ellipsoid::normalized_meridian_arc_unit).
+    /// Closely related to the [normalized meridian arc unit](Meridians::normalized_meridian_arc_unit).
     ///
     /// [Karney (2010)](crate::Bibliography::Kar10) eq. (29), elaborated in
     /// [Deakin et al (2012)](crate::Bibliography::Dea12) eq. (41)
     #[must_use]
-    pub fn rectifying_radius(&self) -> f64 {
+    fn rectifying_radius(&self) -> f64 {
         let n = self.third_flattening();
         self.semimajor_axis() / (1. + n)
             * crate::math::taylor::horner(n * n, &constants::MERIDIAN_ARC_COEFFICIENTS)
@@ -32,11 +32,11 @@ impl Ellipsoid {
     /// The rectifying radius, *A*, following [Bowring (1983)](crate::Bibliography::Bow83):
     /// An utterly elegant way of writing out the series truncated after the *n⁴* term.
     /// In general, however, prefer using the *n⁸* version implemented as
-    /// [rectifying_radius](Ellipsoid::rectifying_radius), based on
+    /// [rectifying_radius](Meridians::rectifying_radius), based on
     /// [Karney (2010)](crate::Bibliography::Kar10) eq. (29), as elaborated in
     /// [Deakin et al (2012)](crate::Bibliography::Dea12) eq. (41)
     #[must_use]
-    pub fn rectifying_radius_bowring(&self) -> f64 {
+    fn rectifying_radius_bowring(&self) -> f64 {
         // A is the rectifying radius - truncated after the n⁴ term
         let n = self.third_flattening();
         let m = 1. + n * n / 8.;
@@ -45,10 +45,10 @@ impl Ellipsoid {
 
     /// The Meridian Quadrant, *Qm*, is the distance from the equator to one of the poles.
     /// i.e. *π/2 · Qn · a*, where *Qn* is the
-    /// [normalized meridian arc unit](Ellipsoid::normalized_meridian_arc_unit)
+    /// [normalized meridian arc unit](Meridians::normalized_meridian_arc_unit)
     #[must_use]
-    pub fn meridian_quadrant(&self) -> f64 {
-        self.a * FRAC_PI_2 * self.normalized_meridian_arc_unit()
+    fn meridian_quadrant(&self) -> f64 {
+        self.semimajor_axis() * FRAC_PI_2 * self.normalized_meridian_arc_unit()
     }
 
     /// The distance, *M*, along a meridian from the equator to the given
@@ -64,7 +64,7 @@ impl Ellipsoid {
     #[must_use]
     #[allow(non_snake_case)] // So we can use the mathematical notation from the original text
     #[allow(clippy::many_single_char_names)] // ditto
-    pub fn meridian_latitude_to_distance(&self, latitude: f64) -> f64 {
+    fn meridian_latitude_to_distance(&self, latitude: f64) -> f64 {
         let n = self.third_flattening();
 
         // The rectifying radius - using a slightly more accurate series than in Bowring (1983)
@@ -87,11 +87,11 @@ impl Ellipsoid {
     /// by [Bowring (1983)](crate::Bibliography::Bow83).
     ///
     /// See also
-    /// [meridian_latitude_to_distance](Ellipsoid::meridian_latitude_to_distance)
+    /// [meridian_latitude_to_distance](Meridians::meridian_latitude_to_distance)
     #[must_use]
     #[allow(non_snake_case)] // So we can use the mathematical notation from the original text
     #[allow(clippy::many_single_char_names)] // ditto
-    pub fn meridian_distance_to_latitude(&self, distance_from_equator: f64) -> f64 {
+    fn meridian_distance_to_latitude(&self, distance_from_equator: f64) -> f64 {
         let n = self.third_flattening();
 
         // Rectifying radius - using a slightly more accurate series than in Bowring (1983)

--- a/src/ellipsoid/mod.rs
+++ b/src/ellipsoid/mod.rs
@@ -1,86 +1,88 @@
-mod cartesians;
+pub mod biaxial;
 mod constants;
-mod geodesics;
-mod gravity;
-mod latitudes;
-mod meridians;
+pub mod geocart;
+pub mod geodesics;
+pub mod gravity;
+pub mod latitudes;
+pub mod meridians;
+pub mod triaxial;
 
 use crate::prelude::*;
 
-/// Representation of a (potentially triaxial) ellipsoid.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Ellipsoid {
-    a: f64,
-    ay: f64,
-    f: f64,
-}
+// Blanket implementations for all the Ellipsoidal traits
+impl<T> Meridians for T where T: EllipsoidBase + ?Sized {}
+impl<T> Latitudes for T where T: EllipsoidBase + ?Sized {}
+impl<T> GeoCart for T where T: EllipsoidBase + ?Sized {}
+impl<T> Geodesics for T where T: EllipsoidBase + ?Sized {}
+impl<T> Gravity for T where T: EllipsoidBase + ?Sized {}
 
-/// GRS80 is the default ellipsoid.
-impl Default for Ellipsoid {
-    fn default() -> Ellipsoid {
-        Ellipsoid::new(6_378_137.0, 1. / 298.257_222_100_882_7)
+/// The fundamental "size and shape" parameters for an ellipsoid.
+/// In general we assume that the ellipsoid is oblate and biaxial,
+/// although triaxial and/or prolate ellipsoids are taken care of
+/// in a few cases. Only required methods are `semimajor_axis` and
+/// `flattening` (and, in the triaxial case, `semimedian_axis`)
+pub trait EllipsoidBase {
+    /// The semimajor axis, *a*
+    fn semimajor_axis(&self) -> f64;
+
+    /// The flattening, *f = (a - b)/a*
+    fn flattening(&self) -> f64;
+
+    /// Synonym for [Self::semimajor_axis]
+    fn a(&self) -> f64 {
+        self.semimajor_axis()
     }
-}
 
-impl Ellipsoid {
-    /// User defined ellipsoid
+    /// Synonym for [Self::flattening]
+    fn f(&self) -> f64 {
+        self.flattening()
+    }
+
+    // ----- Additional axes -------------------------------------------------------
+
+    /// The semimedian axis, *ay*. Equals *a* unless the ellipsoid is triaxial.
     #[must_use]
-    pub fn new(semimajor_axis: f64, flattening: f64) -> Ellipsoid {
-        Ellipsoid {
-            a: semimajor_axis,
-            ay: semimajor_axis,
-            f: flattening,
-        }
+    fn semimedian_axis(&self) -> f64 {
+        self.semimajor_axis()
     }
 
-    pub fn triaxial(semimajor_x_axis: f64, semimajor_y_axis: f64, flattening: f64) -> Ellipsoid {
-        Ellipsoid {
-            a: semimajor_x_axis,
-            ay: semimajor_y_axis,
-            f: flattening,
-        }
+    /// The semiminor axis, *b*
+    #[must_use]
+    fn semiminor_axis(&self) -> f64 {
+        self.semimajor_axis() * (1.0 - self.flattening())
     }
 
-    /// Predefined ellipsoid; built-in or defined in asset collections
-    pub fn named(name: &str) -> Result<Ellipsoid, Error> {
-        // Is it one of the few builtins?
-        if let Some(index) = constants::ELLIPSOID_LIST
-            .iter()
-            .position(|&ellps| ellps.0 == name)
-        {
-            let e = constants::ELLIPSOID_LIST[index];
-            let ax: f64 = e.1.parse().unwrap();
-            let ay: f64 = e.2.parse().unwrap();
-            let rf: f64 = e.3.parse().unwrap();
-            let f = if rf != 0.0 { 1.0 / rf } else { rf };
-            return Ok(Ellipsoid::triaxial(ax, ay, f));
-        }
+    // ----- Additional Flattenings ------------------------------------------------
 
-        // The "semiminor, reciproque-flattening" form, e.g. "6378137, 298.3"
-        let a_and_rf = name.split(',').collect::<Vec<_>>();
-        if a_and_rf.len() == 2_usize {
-            if let Ok(a) = a_and_rf[0].trim().parse::<f64>() {
-                if let Ok(rf) = a_and_rf[1].trim().parse::<f64>() {
-                    return Ok(Ellipsoid::new(a, 1. / rf));
-                }
-            }
-        }
+    /// The second flattening, *g  =  (a - b) / b*
+    #[must_use]
+    fn second_flattening(&self) -> f64 {
+        let b = self.semiminor_axis();
+        (self.a() - b) / b
+    }
 
-        // TODO: Search asset collection
-        Err(Error::NotFound(
-            String::from(name),
-            String::from("Ellipsoid::named()"),
-        ))
+    /// The third flattening, *n  =  (a - b) / (a + b)  =  f / (2 - f)*
+    #[must_use]
+    fn third_flattening(&self) -> f64 {
+        let flattening = self.flattening();
+        flattening / (2.0 - flattening)
+    }
+
+    /// The aspect ratio, *a / b  =  1 / ( 1 - f )  =  1 / sqrt(1 - e²)*
+    #[must_use]
+    fn aspect_ratio(&self) -> f64 {
+        (1.0 - self.flattening()).recip()
     }
 
     // ----- Eccentricities --------------------------------------------------------
 
     /// The linear eccentricity *E* = sqrt(a² - b²). Negative if b > a.
     #[must_use]
-    pub fn linear_eccentricity(&self) -> f64 {
+    fn linear_eccentricity(&self) -> f64 {
+        let a = self.semimajor_axis();
         let b = self.semiminor_axis();
-        let le = self.a * self.a - b * b;
-        if self.a > b {
+        let le = a * a - b * b;
+        if a > b {
             return le.sqrt();
         }
         -(-le).sqrt()
@@ -88,135 +90,71 @@ impl Ellipsoid {
 
     /// The squared eccentricity *e² = (a² - b²) / a²*.
     #[must_use]
-    pub fn eccentricity_squared(&self) -> f64 {
-        self.f * (2_f64 - self.f)
+    fn eccentricity_squared(&self) -> f64 {
+        self.flattening() * (2_f64 - self.flattening())
     }
 
     /// The eccentricity *e*
     #[must_use]
-    pub fn eccentricity(&self) -> f64 {
+    fn eccentricity(&self) -> f64 {
         self.eccentricity_squared().sqrt()
     }
 
     /// The squared second eccentricity *e'² = (a² - b²) / b² = e² / (1 - e²)*
     #[must_use]
-    pub fn second_eccentricity_squared(&self) -> f64 {
+    fn second_eccentricity_squared(&self) -> f64 {
         let es = self.eccentricity_squared();
         es / (1.0 - es)
     }
 
     /// The second eccentricity *e'*
     #[must_use]
-    pub fn second_eccentricity(&self) -> f64 {
+    fn second_eccentricity(&self) -> f64 {
         self.second_eccentricity_squared().sqrt()
-    }
-
-    /// The semimajor axis, *a*
-    #[must_use]
-    pub fn semimajor_axis(&self) -> f64 {
-        self.a
-    }
-
-    /// The semimedian axis, *ay*
-    #[must_use]
-    pub fn semimedian_axis(&self) -> f64 {
-        self.ay
-    }
-
-    /// The semiminor axis, *b*
-    #[must_use]
-    pub fn semiminor_axis(&self) -> f64 {
-        self.a * (1.0 - self.f)
-    }
-
-    // ----- Flattenings -----------------------------------------------------------
-
-    /// The flattening, *f = (a - b)/a*
-    #[must_use]
-    pub fn flattening(&self) -> f64 {
-        self.f
-    }
-
-    /// The second flattening, *f = (a - b) / b*
-    #[must_use]
-    pub fn second_flattening(&self) -> f64 {
-        let b = self.semiminor_axis();
-        (self.a - b) / b
-    }
-
-    /// The third flattening, *n = (a - b) / (a + b) = f / (2 - f)*
-    #[must_use]
-    pub fn third_flattening(&self) -> f64 {
-        self.f / (2.0 - self.f)
-    }
-
-    /// The aspect ratio, *b / a  =  1 - f  =  sqrt(1 - e²)*
-    #[must_use]
-    pub fn aspect_ratio(&self) -> f64 {
-        1.0 - self.f
     }
 
     // ----- Curvatures ------------------------------------------------------------
 
     /// The radius of curvature in the prime vertical, *N*
     #[must_use]
-    pub fn prime_vertical_radius_of_curvature(&self, latitude: f64) -> f64 {
-        if self.f == 0.0 {
-            return self.a;
+    fn prime_vertical_radius_of_curvature(&self, latitude: f64) -> f64 {
+        let a = self.semimajor_axis();
+        if self.flattening() == 0.0 {
+            return a;
         }
-        self.a / (1.0 - latitude.sin().powi(2) * self.eccentricity_squared()).sqrt()
+        a / (1.0 - latitude.sin().powi(2) * self.eccentricity_squared()).sqrt()
     }
 
     /// The meridian radius of curvature, *M*
     #[must_use]
-    pub fn meridian_radius_of_curvature(&self, latitude: f64) -> f64 {
-        if self.f == 0.0 {
-            return self.a;
+    fn meridian_radius_of_curvature(&self, latitude: f64) -> f64 {
+        if self.flattening() == 0.0 {
+            return self.semimajor_axis();
         }
-        let num = self.a * (1.0 - self.eccentricity_squared());
+        let num = self.semimajor_axis() * (1.0 - self.eccentricity_squared());
         let denom = (1.0 - latitude.sin().powi(2) * self.eccentricity_squared()).powf(1.5);
         num / denom
     }
 
     /// The polar radius of curvature, *c*
     #[must_use]
-    pub fn polar_radius_of_curvature(&self) -> f64 {
-        self.a * self.a / self.semiminor_axis()
+    fn polar_radius_of_curvature(&self) -> f64 {
+        let a = self.semimajor_axis();
+        a * a / self.semiminor_axis()
     }
 }
-
-// ----- Tests ---------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_ellipsoid() -> Result<(), Error> {
-        // Constructors
-        let ellps = Ellipsoid::named("intl")?;
-        assert_eq!(ellps.flattening(), 1. / 297.);
-
-        let ellps = Ellipsoid::named("6378137, 298.25")?;
-        assert_eq!(ellps.semimajor_axis(), 6378137.0);
-        assert_eq!(ellps.flattening(), 1. / 298.25);
-
-        let ellps = Ellipsoid::named("GRS80")?;
-        assert_eq!(ellps.semimajor_axis(), 6378137.0);
-        assert_eq!(ellps.flattening(), 1. / 298.257_222_100_882_7);
-
-        assert!((ellps.normalized_meridian_arc_unit() - 0.998_324_298_423_041_5).abs() < 1e-13);
-        assert!((4.0 * ellps.meridian_quadrant() - 40_007_862.916_921_8).abs() < 1e-7);
-        Ok(())
-    }
-
-    #[test]
     fn shape_and_size() -> Result<(), Error> {
         let ellps = Ellipsoid::named("GRS80")?;
         let ellps = Ellipsoid::new(ellps.semimajor_axis(), ellps.flattening());
-        let ellps = Ellipsoid::triaxial(ellps.a, ellps.a - 1., ellps.f);
-        assert_eq!(ellps.semimajor_axis(), 6378137.0);
-        assert_eq!(ellps.flattening(), 1. / 298.257_222_100_882_7);
+        // let ellps = Ellipsoid::triaxial(ellps.a, ellps.a - 1., ellps.f);
+        // assert_eq!(ellps.semimajor_axis(), 6378137.0);
+        // assert_eq!(ellps.flattening(), 1. / 298.257_222_100_882_7);
 
         // Additional shape descriptors
         assert!((ellps.eccentricity() - 0.081819191).abs() < 1.0e-10);

--- a/src/ellipsoid/triaxial.rs
+++ b/src/ellipsoid/triaxial.rs
@@ -1,0 +1,115 @@
+use crate::prelude::*;
+
+/// A triaxial ellipsoid. Currently mostly a placeholder for future use.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TriaxialEllipsoid {
+    a: f64,
+    ay: f64,
+    f: f64,
+}
+
+/// GRS80 is the default ellipsoid.
+impl Default for TriaxialEllipsoid {
+    fn default() -> TriaxialEllipsoid {
+        TriaxialEllipsoid::new(6_378_137.0, 6_378_137.0, 1. / 298.257_222_100_882_7)
+    }
+}
+
+impl EllipsoidBase for TriaxialEllipsoid {
+    fn semimajor_axis(&self) -> f64 {
+        self.a
+    }
+
+    fn semimedian_axis(&self) -> f64 {
+        self.ay
+    }
+
+    fn flattening(&self) -> f64 {
+        self.f
+    }
+}
+
+/// Constructors for `Ellipsoid`
+impl TriaxialEllipsoid {
+    /// User defined ellipsoid
+    #[must_use]
+    pub fn new(semimajor_axis: f64, semimedian_axis: f64, flattening: f64) -> TriaxialEllipsoid {
+        TriaxialEllipsoid {
+            a: semimajor_axis,
+            ay: semimedian_axis,
+            f: flattening,
+        }
+    }
+
+    /// Predefined ellipsoid; built-in, defined in asset collections, or given as a string formatted
+    /// (a, rf) or (ax, ay, rx) tuple, e.g. "6378137, 298.25" or "6378137, 6345678, 300"
+    pub fn named(name: &str) -> Result<TriaxialEllipsoid, Error> {
+        // Is it one of the few builtins?
+        if let Some(index) = super::constants::ELLIPSOID_LIST
+            .iter()
+            .position(|&ellps| ellps.0 == name)
+        {
+            let e = super::constants::ELLIPSOID_LIST[index];
+            let ax: f64 = e.1.parse().unwrap();
+            let ay: f64 = e.2.parse().unwrap();
+            let rf: f64 = e.3.parse().unwrap();
+            // EPSG convention: zero reciproque flattening indicates zero flattening
+            let f = if rf != 0.0 { 1.0 / rf } else { rf };
+            return Ok(TriaxialEllipsoid::new(ax, ay, f));
+        }
+
+        // The "semimajor, semimedian, reciproque-flattening" form, e.g. "6378137, 6345678, 298.3"
+        let a_and_rf = name.split(',').collect::<Vec<_>>();
+        let n = a_and_rf.len();
+        let semimedian_index = if n == 2 { 0 } else { 1 };
+        if [2usize, 3].contains(&n) {
+            if let Ok(ax) = a_and_rf[0].trim().parse::<f64>() {
+                if let Ok(ay) = a_and_rf[semimedian_index].trim().parse::<f64>() {
+                    if let Ok(rf) = a_and_rf[semimedian_index + 1].trim().parse::<f64>() {
+                        return Ok(TriaxialEllipsoid::new(ax, ay, 1. / rf));
+                    }
+                }
+            }
+        }
+
+        // TODO: Search asset collection
+        Err(Error::NotFound(
+            String::from(name),
+            String::from("Ellipsoid::named()"),
+        ))
+    }
+}
+
+// ----- Tests ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::ellps::EllipsoidBase;
+    use crate::ellps::Meridians;
+    use crate::ellps::TriaxialEllipsoid;
+    use crate::Error;
+
+    #[test]
+    fn test_triaxial_ellipsoid() -> Result<(), Error> {
+        // Constructors
+        let ellps = TriaxialEllipsoid::named("intl")?;
+        assert_eq!(ellps.flattening(), 1. / 297.);
+
+        let ellps = TriaxialEllipsoid::named("6378137, 298.25")?;
+        assert_eq!(ellps.semimajor_axis(), 6378137.0);
+        assert_eq!(ellps.flattening(), 1. / 298.25);
+
+        let ellps = TriaxialEllipsoid::named("6378137, 6345678, 298.25")?;
+        assert_eq!(ellps.semimajor_axis(), 6378137.0);
+        assert_eq!(ellps.semimedian_axis(), 6345678.0);
+        assert_eq!(ellps.flattening(), 1. / 298.25);
+
+        let ellps = TriaxialEllipsoid::named("GRS80")?;
+        assert_eq!(ellps.semimajor_axis(), 6378137.0);
+        assert_eq!(ellps.flattening(), 1. / 298.257_222_100_882_7);
+
+        assert!((ellps.normalized_meridian_arc_unit() - 0.998_324_298_423_041_5).abs() < 1e-13);
+        assert!((4.0 * ellps.meridian_quadrant() - 40_007_862.916_921_8).abs() < 1e-7);
+        Ok(())
+    }
+}

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -19,7 +19,7 @@ pub trait Grid: Debug + Sync + Send {
 /// Grid characteristics and interpolation.
 ///
 /// The actual grid may be part of the `BaseGrid` struct, or
-/// provided externally (presumably by a [Context](crate::Context)).
+/// provided externally (presumably by a [Context](crate::context::Context)).
 ///
 /// In principle grid format agnostic, but includes a parser for
 /// geodetic grids in the Gravsoft format.

--- a/src/grid/ntv2/mod.rs
+++ b/src/grid/ntv2/mod.rs
@@ -3,7 +3,7 @@ mod subgrid;
 
 use self::subgrid::NODE_SIZE;
 use super::BaseGrid;
-use crate::{Coor4D, Error, Grid};
+use crate::{coord::Coor4D, grid::Grid, Error};
 use parser::{NTv2Parser, HEADER_SIZE};
 use std::collections::BTreeMap;
 

--- a/src/inner_op/deformation.rs
+++ b/src/inner_op/deformation.rs
@@ -360,7 +360,7 @@ mod tests {
         // works identically to the hand held incantations above
         let op = ctx.op("deformation dt=1000 grids=test.deformation")?;
         // Create a test data point in the cartesian space
-        let ellps = crate::Ellipsoid::default();
+        let ellps = Ellipsoid::default();
         let cph = ellps.cartesian(&cph);
 
         // Check the length of the correction after a forward step

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,67 +1,22 @@
 #![doc = include_str!("../README.md")]
 
-/// The bread-and-butter, shrink-wrapped for external use
+/// The bread-and-butter, shrink-wrapped and ready to use
 pub mod prelude {
-    // Context related
-    pub use crate::Context;
-    pub use crate::Direction;
-    pub use crate::Direction::Fwd;
-    pub use crate::Direction::Inv;
-    pub use crate::Minimal;
-    pub use crate::OpHandle;
-    #[cfg(feature = "with_plain")]
-    pub use crate::Plain;
-
-    // Coordinate related
-    pub use crate::math::angular;
-    pub use crate::AngularUnits;
-    pub use crate::Coor2D;
-    pub use crate::Coor32;
-    pub use crate::Coor3D;
-    pub use crate::Coor4D;
-    pub use crate::CoordinateMetadata;
-    pub use crate::CoordinateSet;
-    pub use crate::CoordinateTuple;
-
-    // Et cetera
-    pub use crate::Ellipsoid;
+    pub use crate::coord::*;
+    pub use crate::ctx::*;
+    pub use crate::ellps::*;
+    #[allow(unused_imports)]
+    pub use crate::test_coords::*;
     pub use crate::Error;
-
-    #[cfg(test)]
-    pub fn some_basic_coor4dinates() -> [Coor4D; 2] {
-        let copenhagen = Coor4D::raw(55., 12., 0., 0.);
-        let stockholm = Coor4D::raw(59., 18., 0., 0.);
-        [copenhagen, stockholm]
-    }
-    #[cfg(test)]
-    pub fn some_basic_coor3dinates() -> [Coor3D; 2] {
-        let copenhagen = Coor3D::raw(55., 12., 0.);
-        let stockholm = Coor3D::raw(59., 18., 0.);
-        [copenhagen, stockholm]
-    }
-    #[cfg(test)]
-    pub fn some_basic_coor2dinates() -> [Coor2D; 2] {
-        let copenhagen = Coor2D::raw(55., 12.);
-        let stockholm = Coor2D::raw(59., 18.);
-        [copenhagen, stockholm]
-    }
 }
 
-/// Extended prelude for authoring Contexts and InnerOp modules (built-in or user defined)
+/// Extended prelude for authoring Contexts and InnerOp modules
 pub mod authoring {
-    pub use crate::prelude::*;
-
-    pub use crate::grid::grids_at;
-    pub use crate::grid::BaseGrid;
-    pub use crate::grid::Grid;
+    pub use crate::grd::*;
     pub use crate::math::*;
-    pub use crate::InnerOp;
-    pub use crate::Op;
-    pub use crate::OpConstructor;
-    pub use crate::OpDescriptor;
-    pub use crate::OpParameter;
-    pub use crate::ParsedParameters;
-    pub use crate::RawParameters;
+    pub use crate::ops::*;
+    pub use crate::parse::*;
+    pub use crate::prelude::*;
 
     // All new contexts are supposed to support these
     pub use crate::context::BUILTIN_ADAPTORS;
@@ -70,9 +25,6 @@ pub mod authoring {
     pub use crate::math::jacobian::Factors;
     pub use crate::math::jacobian::Jacobian;
 
-    pub use crate::parse_proj;
-    pub use crate::Tokenize;
-
     // External material
     pub use log::debug;
     pub use log::error;
@@ -80,6 +32,96 @@ pub mod authoring {
     pub use log::trace;
     pub use log::warn;
     pub use std::collections::BTreeMap;
+}
+
+/// Context related elements
+pub mod ctx {
+    pub use crate::context::minimal::Minimal;
+    #[cfg(feature = "with_plain")]
+    pub use crate::context::plain::Plain;
+    pub use crate::context::Context;
+    pub use crate::op::OpHandle;
+    pub use crate::Direction;
+    pub use crate::Direction::Fwd;
+    pub use crate::Direction::Inv;
+}
+
+/// Ellipsoid related elements
+pub mod ellps {
+    pub use crate::ellipsoid::biaxial::Ellipsoid;
+    pub use crate::ellipsoid::geocart::GeoCart;
+    pub use crate::ellipsoid::geodesics::Geodesics;
+    pub use crate::ellipsoid::gravity::Gravity;
+    pub use crate::ellipsoid::latitudes::Latitudes;
+    pub use crate::ellipsoid::meridians::Meridians;
+    pub use crate::ellipsoid::triaxial::TriaxialEllipsoid;
+    pub use crate::ellipsoid::EllipsoidBase;
+}
+
+/// Coordinate related elements
+pub mod coord {
+    // Coordinate types
+    pub use crate::coordinate::coor2d::Coor2D;
+    pub use crate::coordinate::coor32::Coor32;
+    pub use crate::coordinate::coor3d::Coor3D;
+    pub use crate::coordinate::coor4d::Coor4D;
+    // Coordinate traits
+    pub use crate::coordinate::set::CoordinateSet;
+    pub use crate::coordinate::tuple::CoordinateTuple;
+    pub use crate::coordinate::AngularUnits;
+    pub use crate::coordinate::CoordinateMetadata;
+    pub use crate::math::angular;
+}
+
+/// Some generic coordintes for test composition
+mod test_coords {
+    #[cfg(test)]
+    pub fn some_basic_coor4dinates() -> [crate::coord::Coor4D; 2] {
+        let copenhagen = crate::coord::Coor4D::raw(55., 12., 0., 0.);
+        let stockholm = crate::coord::Coor4D::raw(59., 18., 0., 0.);
+        [copenhagen, stockholm]
+    }
+
+    #[cfg(test)]
+    pub fn some_basic_coor3dinates() -> [crate::coord::Coor3D; 2] {
+        let copenhagen = crate::coord::Coor3D::raw(55., 12., 0.);
+        let stockholm = crate::coord::Coor3D::raw(59., 18., 0.);
+        [copenhagen, stockholm]
+    }
+
+    #[cfg(test)]
+    pub fn some_basic_coor2dinates() -> [crate::coord::Coor2D; 2] {
+        let copenhagen = crate::coord::Coor2D::raw(55., 12.);
+        let stockholm = crate::coord::Coor2D::raw(59., 18.);
+        [copenhagen, stockholm]
+    }
+}
+
+/// Elements for building operators
+mod ops {
+    pub use crate::inner_op::InnerOp;
+    pub use crate::inner_op::OpConstructor;
+    pub use crate::op::Op;
+    pub use crate::op::OpDescriptor;
+    pub use crate::op::OpParameter;
+    pub use crate::op::ParsedParameters;
+    pub use crate::op::RawParameters;
+}
+
+/// Elements for handling grids
+mod grd {
+    pub use crate::grid::grids_at;
+    pub use crate::grid::ntv2::Ntv2Grid;
+    pub use crate::grid::BaseGrid;
+    pub use crate::grid::Grid;
+}
+
+/// Elements for parsing both Geodesy and PROJ syntax
+mod parse {
+    // Tokenizing Rust Geodesy operations
+    pub use crate::token::Tokenize;
+    // PROJ interoperability
+    pub use crate::token::parse_proj;
 }
 
 use thiserror::Error;
@@ -151,57 +193,10 @@ mod coordinate;
 mod ellipsoid;
 mod grid;
 mod inner_op;
-pub mod math;
+mod math;
 mod op;
 mod token;
 
-// ---- Context providers ----
-
-// The Context trait and the two implementing built-in types
-pub use crate::context::Context;
-
-pub use crate::context::minimal::Minimal;
-#[cfg(feature = "with_plain")]
-pub use crate::context::plain::Plain;
-
-// Specify which operator to apply in `Context::apply(...)`
-pub use crate::op::OpHandle;
-
-// ---- Coordinates and ellipsoids ----
-
-// Ellipsoidal operations
-pub use crate::ellipsoid::Ellipsoid;
-
-// Coordinate types
-pub use crate::coordinate::coor2d::Coor2D;
-pub use crate::coordinate::coor32::Coor32;
-pub use crate::coordinate::coor3d::Coor3D;
-pub use crate::coordinate::coor4d::Coor4D;
-// Coordinate traits
-pub use crate::coordinate::set::CoordinateSet;
-pub use crate::coordinate::tuple::CoordinateTuple;
-pub use crate::coordinate::AngularUnits;
-pub use crate::coordinate::CoordinateMetadata;
-
-// ---- Et cetera ----
-
-// Tokenizing Rust Geodesy operations
-pub use crate::token::Tokenize;
-
-// PROJ interoperability
-pub use crate::token::parse_proj;
-
-// The lower level data types, mostly use in the extended prelude 'authoring'
-pub use crate::grid::Grid;
-pub use crate::inner_op::InnerOp;
-pub use crate::inner_op::OpConstructor;
-pub use crate::op::Op;
-pub use crate::op::OpDescriptor;
-pub use crate::op::OpParameter;
-pub use crate::op::ParsedParameters;
-pub use crate::op::RawParameters;
-
-pub use crate::grid::ntv2::Ntv2Grid;
-
+// ---- Documentation: Bibliography ----
 #[cfg(doc)]
 pub use crate::bibliography::Bibliography;

--- a/src/math/series.rs
+++ b/src/math/series.rs
@@ -197,7 +197,7 @@ pub mod fourier {
 #[cfg(test)]
 mod tests {
     use super::taylor::*;
-    use crate::{Ellipsoid, Error};
+    use crate::authoring::*;
 
     #[test]
     fn test_horner() -> Result<(), Error> {


### PR DESCRIPTION
The Ellipsoid impl was huge and unmaintainable.

Now it has been split into an EllipsoidBase trait, defining the fundamental shape and size parameters, and a number of more specialized traits for latitudes, meridian-geometry, geodesics, cartesians (geocart), and gravity.

Also lib.rs was cleaned up to reflect the new structure, and the prelude has been rebuilt using thematical modules: coord, ctx, and ellps, representing coordinate, context, and ellipsoidal material, respectively.

Likewise, the "authoring" extended prelude has been restructured through the introduction of the grd,
ops, and parse modules.

Finally, a number of documentation improvements were introduced while refactoring the existing material to reflect the new structure.

For usage based on the "use geodesy::prelude::*" idiom, no user visible changes are expected.